### PR TITLE
Expose 'dwn-response' header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dwn-server",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dwn-server",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "dependencies": {
                 "@tbd54566975/dwn-sdk-js": "0.0.30",
                 "bytes": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "dwn-server",
     "type": "module",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "dependencies": {
         "@tbd54566975/dwn-sdk-js": "0.0.30",
         "bytes": "3.1.2",

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -18,7 +18,7 @@ export class HttpApi {
     this.api = express();
     this.dwn = dwn;
 
-    this.api.use(cors());
+    this.api.use(cors({ exposedHeaders: 'dwn-response' }));
 
     this.api.get('/health', (_req, res) => {
       // return 200 ok

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -45,6 +45,19 @@ describe('http api', function() {
     expect(body.error.message).to.include('JSON');
   });
 
+  it('exposes dwn-response header', async function() {
+    const response = await request(httpApi.api)
+      .post('/')
+      .send();
+
+    // Check if the 'access-control-expose-headers' header is present
+    expect(response.headers).to.have.property('access-control-expose-headers');
+
+    // Check if the 'dwn-response' header is listed in 'access-control-expose-headers'
+    const exposedHeaders = response.headers['access-control-expose-headers'];
+    expect(exposedHeaders).to.include('dwn-response');
+  });
+
   it('works fine when no request body is provided', async function() {
     const alice = await createProfile();
     const recordsQuery = await RecordsQuery.create({

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -46,6 +46,14 @@ describe('http api', function() {
   });
 
   it('exposes dwn-response header', async function() {
+    // This test verifies that the Express web server includes `dwn-response` in the list of
+    // `access-control-expose-headers` returned in each HTTP response. This is necessary to enable applications
+    // that have CORS enabled to read and parse DWeb Messages that are returned as Response headers, particularly
+    // in the case of RecordsRead messages.
+
+    // TODO: Consider replacing this test with a more robust method of testing, such as writing Playwright tests
+    // that run in a browser to verify that the `dwn-response` header can be read from the `fetch()` response
+    // when CORS mode is enabled.
     const response = await request(httpApi.api)
       .post('/')
       .send();


### PR DESCRIPTION
This PR adds configuration to the Express web server to add the `dwn-response` header to the list of `access-control-expose-headers` returned in each HTTP response.

This is necessary to enable applications that have CORS enabled to read and parse DWeb Messages that are returned as Response headers, particularly in the case of RecordsRead messages that use the HTTP body for the data payload.