### PR TITLE
Handle payload data consistently for HTTP and WS and account for no data scenario

### DIFF
--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -1,6 +1,6 @@
+import type { Express, Request } from 'express';
 import type { Dwn } from '@tbd54566975/dwn-sdk-js';
 import type { RequestContext } from './lib/json-rpc-router.js';
-import type { Express, Request } from 'express';
 
 import cors from 'cors';
 import express from 'express';
@@ -43,14 +43,19 @@ export class HttpApi {
         return res.status(400).json(reply);
       }
 
-      const requestContext: RequestContext = { dwn: this.dwn, transport: 'http', dataStream: req };
-      const { jsonRpcResponse, dataStream } = await jsonRpcApi.handle(dwnRequest, requestContext as RequestContext);
+      // Check whether data was provided in the request body
+      const contentLength = req.headers['content-length'];
+      const transferEncoding = req.headers['transfer-encoding'];
+      const requestDataStream = (parseInt(contentLength) > 0 || transferEncoding !== undefined) ? req : undefined;
 
-      if (dataStream) {
+      const requestContext: RequestContext = { dwn: this.dwn, transport: 'http', dataStream: requestDataStream };
+      const { jsonRpcResponse, dataStream: responseDataStream } = await jsonRpcApi.handle(dwnRequest, requestContext as RequestContext);
+
+      if (responseDataStream) {
         res.setHeader('content-type', 'application/octet-stream');
         res.setHeader('dwn-response', JSON.stringify(jsonRpcResponse));
 
-        return dataStream.pipe(res);
+        return responseDataStream.pipe(res);
       } else {
         return res.json(jsonRpcResponse);
       }

--- a/src/json-rpc-handlers/dwn/process-message.ts
+++ b/src/json-rpc-handlers/dwn/process-message.ts
@@ -1,8 +1,6 @@
 import type { Readable as IsomorphicReadable } from 'readable-stream';
 import type { JsonRpcHandler, HandlerResponse } from '../../lib/json-rpc-router.js';
 
-import { base64url } from 'multiformats/bases/base64';
-import { DataStream } from '@tbd54566975/dwn-sdk-js';
 import { v4 as uuidv4 } from 'uuid';
 
 import { JsonRpcErrorCodes, createJsonRpcErrorResponse, createJsonRpcSuccessResponse } from '../../lib/json-rpc.js';
@@ -12,12 +10,6 @@ export const handleDwnProcessMessage: JsonRpcHandler = async (dwnRequest, contex
   const { target, message } = dwnRequest.params;
 
   const requestId = dwnRequest.id ?? uuidv4();
-
-  // data can either be provided in the dwnRequest itself or as a stream
-  if (!dataStream) {
-    const { encodedData } = dwnRequest.params;
-    dataStream = encodedData ? DataStream.fromBytes(base64url.baseDecode(encodedData)) : undefined;
-  }
 
   try {
     const reply = await dwn.processMessage(target, message, dataStream as IsomorphicReadable);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -38,7 +38,23 @@ export async function createProfile(): Promise<Profile> {
   };
 }
 
-export type CreateRecordsWriteOverrides = ({ dataSize?: number; dataCid?: string } & { data?: never }) | ({ dataSize?: never; dataCid?: never } & { data?: Uint8Array });
+export type CreateRecordsWriteOverrides = (
+  {
+    dataCid?: string;
+    dataSize?: number;
+    dateCreated?: string;
+    published?: boolean;
+    recordId?: string
+  } & { data?: never })
+  |
+  ({
+    dataCid?: never;
+    dataSize?: never;
+    dateCreated?: string;
+    published?: boolean;
+    recordId?: string
+  } & { data?: Uint8Array }
+);
 
 export async function createRecordsWriteMessage(signer: Profile, overrides: CreateRecordsWriteOverrides = {}) {
   if (!overrides.dataCid && !overrides.data) {


### PR DESCRIPTION
## What's Changed

- Both `http-api.ts` and `ws-api.ts` now check for the presence of data before handing off to the `dwn/process-message.ts` handler.  This normalizes the output of the APIs so that there isn't any transport specific _request_ data handling logic in `dwn/process-message.ts`.
- Fixed case that would return an error in the event that a DWN Request did not include any data in the HTTP Request body.  This occurs most commonly in the case of a subsequent `RecordsWrite` that overwrites a mutable property (e.g., `published`) but does not mutate a record's data.