### PR TITLE
Improve error handling

### DIFF
--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -10,6 +10,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { jsonRpcApi } from './json-rpc-api.js';
 import { createJsonRpcErrorResponse, JsonRpcErrorCodes } from './lib/json-rpc.js';
 
+const jsonRpcErrorToHttpStatusCode: { [key: number]: number } = {
+  [JsonRpcErrorCodes.BadRequest]   : 400,
+  [JsonRpcErrorCodes.Unauthorized] : 401,
+  [JsonRpcErrorCodes.Forbidden]    : 403,
+};
+
 export class HttpApi {
   api: Express;
   dwn: Dwn;
@@ -53,11 +59,6 @@ export class HttpApi {
 
       // If the handler returns an error response, return the equivalent HTTP status code with the response
       if (jsonRpcResponse.error) {
-        const jsonRpcErrorToHttpStatusCode: { [key: number]: number } = {
-          [JsonRpcErrorCodes.BadRequest]   : 400,
-          [JsonRpcErrorCodes.Unauthorized] : 401,
-          [JsonRpcErrorCodes.Forbidden]    : 403,
-        };
         const statusCode = jsonRpcErrorToHttpStatusCode[jsonRpcResponse.error.code] || 500;
         return res.status(statusCode).json(jsonRpcResponse);
       }

--- a/src/json-rpc-handlers/dwn/process-message.ts
+++ b/src/json-rpc-handlers/dwn/process-message.ts
@@ -16,7 +16,7 @@ export const handleDwnProcessMessage: JsonRpcHandler = async (dwnRequest, contex
 
     if (reply.status.code >= 400) {
       const jsonRpcResponse = createJsonRpcErrorResponse(requestId,
-        JsonRpcErrorCodes.BadRequest, reply.status.detail);
+        JsonRpcErrorCodes.BadRequest, reply.status.detail, { status: { code: reply.status.code }});
 
       return { jsonRpcResponse } as HandlerResponse;
     }
@@ -24,7 +24,7 @@ export const handleDwnProcessMessage: JsonRpcHandler = async (dwnRequest, contex
     // RecordsRead messages return record data as a stream to for accommodate large amounts of data
     let recordDataStream;
     if ('record' in reply) {
-      // TODO: export `RecordsReadReply` from dwn-sdk-js
+      // TODO: Import `RecordsReadReply` from dwn-sdk-js once release with https://github.com/TBD54566975/dwn-sdk-js/pull/346 is available
       recordDataStream = reply.record['data'];
       delete reply.record['data'];
     }

--- a/tests/dwn-process-message.spec.ts
+++ b/tests/dwn-process-message.spec.ts
@@ -1,0 +1,57 @@
+import type { RequestContext } from '../src/lib/json-rpc-router.js';
+
+import { expect } from 'chai';
+import { v4 as uuidv4 } from 'uuid';
+
+import { dwn, clear as clearDwn } from './test-dwn.js';
+import { createProfile, createRecordsWriteMessage } from './utils.js';
+import { createJsonRpcRequest, JsonRpcErrorCodes } from '../src/lib/json-rpc.js';
+import { handleDwnProcessMessage } from '../src/json-rpc-handlers/dwn/process-message.js';
+
+describe('handleDwnProcessMessage', function() {
+  afterEach(async function() {
+    await clearDwn();
+  });
+
+  it('returns a DWN status code when processed successfully', async function() {
+    const alice = await createProfile();
+
+    // Construct a well-formed DWN Request that will be successfully processed
+    const { recordsWrite, dataStream } = await createRecordsWriteMessage(alice);
+    const requestId = uuidv4();
+    const dwnRequest = createJsonRpcRequest(requestId, 'dwn.processMessage', {
+      message : recordsWrite.toJSON(),
+      target  : alice.did,
+    });
+
+    const context: RequestContext = { dwn, transport: 'http', dataStream };
+
+    const { jsonRpcResponse } = await handleDwnProcessMessage(dwnRequest, context);
+
+    expect(jsonRpcResponse.error).to.not.exist;
+    const { reply } = jsonRpcResponse.result;
+    expect(reply.status.code).to.equal(202);
+    expect(reply.status.detail).to.equal('Accepted');
+  });
+
+  it('returns a DWN status code when processing fails', async function() {
+    // Construct a DWN Request that is missing the descriptor `method` property to ensure
+    // that `dwn.processMessage()` will return an error status
+    const requestId = uuidv4();
+    const dwnRequest = createJsonRpcRequest(requestId, 'dwn.processMessage', {
+      message: {
+        descriptor: { interface: 'Records' }
+      },
+      target: 'did:key:abc1234',
+    });
+
+    const context: RequestContext = { dwn, transport: 'http' };
+
+    const { jsonRpcResponse } = await handleDwnProcessMessage(dwnRequest, context);
+
+    expect(jsonRpcResponse.error).to.exist;
+    const { error } = jsonRpcResponse;
+    expect(error.code).to.equal(JsonRpcErrorCodes.BadRequest);
+    expect(error.data).to.have.nested.property('status.code', 400);
+  });
+});


### PR DESCRIPTION
## What's Changed

- This PR modifies error handling in two areas, as noted below.
- It resolves https://github.com/TBD54566975/dwn-server/issues/15
- It also updates [this TODO](https://github.com/TBD54566975/dwn-server/blob/c223eb2dec240d9759e9c5d3204a30ef6e741c31/src/json-rpc-handlers/dwn/process-message.ts#L27) to reflect that [RecordsReadReply](https://github.com/TBD54566975/dwn-sdk-js/pull/346) is now being exported by `dwn-sdk-js` and the type can be imported once a new DWN SDK release is published.

---

**[1] Return DWN status code with JSON RPC error responses**

Previously if [`dwn/process-message.ts`](https://github.com/TBD54566975/dwn-server/blob/c223eb2dec240d9759e9c5d3204a30ef6e741c31/src/json-rpc-handlers/dwn/process-message.ts) successfully processed the DWN Request, it would return the entire DWN SDK `status` object (i.e., both `status.code` and `status.detail`):
https://github.com/TBD54566975/dwn-server/blob/c223eb2dec240d9759e9c5d3204a30ef6e741c31/src/json-rpc-handlers/dwn/process-message.ts#L15
https://github.com/TBD54566975/dwn-server/blob/c223eb2dec240d9759e9c5d3204a30ef6e741c31/src/json-rpc-handlers/dwn/process-message.ts#L32
However, in the event of a DWN SDK error response, only the `status.detail` was returned (i.e., `status.code` was discarded).  Practically, this resulted in having to add additional logging to disambiguate DWN errors when troubleshooting issues in other libs that were interacting with a DWN instance via `dwn-server`.

https://github.com/TBD54566975/dwn-server/blob/b15e25b3016829aa021ab2e183c19b4083784f89/src/json-rpc-handlers/dwn/process-message.ts#L17-L19

The modification made was to include the `status.code` returned from DWN SDK in the JSON RPC error response `data` property to ensure a developer has the value when troubleshooting issues:

https://github.com/TBD54566975/dwn-server/blob/c223eb2dec240d9759e9c5d3204a30ef6e741c31/src/json-rpc-handlers/dwn/process-message.ts#L19

---

**[2] Return HTTP 4XX/5XX status codes when `handleDwnProcessMessage` returns an error**

Previously, if DWN SDK `dwn.processMessage()` returned an error, [`dwn/process-message.ts`](https://github.com/TBD54566975/dwn-server/blob/c223eb2dec240d9759e9c5d3204a30ef6e741c31/src/json-rpc-handlers/dwn/process-message.ts) would properly return a JSON RPC Error Response to [`http-api.ts`](https://github.com/TBD54566975/dwn-server/blob/b15e25b3016829aa021ab2e183c19b4083784f89/src/http-api.ts) here:

https://github.com/TBD54566975/dwn-server/blob/c223eb2dec240d9759e9c5d3204a30ef6e741c31/src/json-rpc-handlers/dwn/process-message.ts#L17-L22

However, upon receiving the error response, [`http-api.ts`](https://github.com/TBD54566975/dwn-server/blob/b15e25b3016829aa021ab2e183c19b4083784f89/src/http-api.ts) would still return an HTTP Response with a status code of `200` here:

https://github.com/TBD54566975/dwn-server/blob/b15e25b3016829aa021ab2e183c19b4083784f89/src/http-api.ts#L58-L67

Practically, this results in a lib/app interacting with a `dwn-server` processing the HTTP Response as if it were successfully completed, even though the RPC call failed because the embedded DWN could not complete the request.

As a result, in the event an error condition was encountered on one `dwn-server` instance, but a particular DID had multiple service endpoints defined, the return of status `200` would cause a library like Web5 JS to skip trying the other DWN endpoints due to the perception of success.

The modification made was to check for an error condition in the JSON RPC Handler response and to map the RPC error code to its HTTP equivalent (e.g., -50400 maps to 400, -50401 maps to 401, -50403 maps to 403).  If any other error is encountered (e.g., [JSON-RPC 2.0 pre-defined errors](https://www.jsonrpc.org/specification) -32768 to -32000), HTTP status 500 (internal server error) is returned:

https://github.com/TBD54566975/dwn-server/blob/c223eb2dec240d9759e9c5d3204a30ef6e741c31/src/http-api.ts#L55-L63

This attempts to balance simplicity of not mapping every possible error but providing the appropriate HTTP response to disambiguate 400, 401, and 403.  In other words:
- [400 Bad Request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) "indicates that the server cannot or will not process the request due to something that is perceived to be a client error."  The suggested reaction is that "The client should not repeat this request without modification."
- [401 Not Authorized](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) "indicates that the client request has not been completed because it lacks valid authentication credentials for the requested resource."  "In situations resulting in this status code, user authentication can allow access to the resource" so retry of the request after authentication succeeds is advisable.
- [403 Forbidden](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) "indicates that the server understands the request but refuses to authorize it."  In this case, "re-authenticating makes no difference" so the client shouldn't try again unless they have a way to gain elevated authorization/permissions.