### PR TITLE
Changes to error handling and improvement to HTTP server test cases

### DIFF
--- a/src/json-rpc-handlers/dwn/process-message.ts
+++ b/src/json-rpc-handlers/dwn/process-message.ts
@@ -14,13 +14,6 @@ export const handleDwnProcessMessage: JsonRpcHandler = async (dwnRequest, contex
   try {
     const reply = await dwn.processMessage(target, message, dataStream as IsomorphicReadable);
 
-    if (reply.status.code >= 400) {
-      const jsonRpcResponse = createJsonRpcErrorResponse(requestId,
-        JsonRpcErrorCodes.BadRequest, reply.status.detail, { status: { code: reply.status.code }});
-
-      return { jsonRpcResponse } as HandlerResponse;
-    }
-
     // RecordsRead messages return record data as a stream to for accommodate large amounts of data
     let recordDataStream;
     if ('record' in reply) {


### PR DESCRIPTION
## What's changed:

### 1. Changes to error handling:
- Previously, if `dwn.processMessage()` returned a status code >= 400, this error would be mapped to an HTTP status
  code and returned.  The end result is that it would appear to a calling application (e.g., `Web5UserAgent`) that the
  request failed, when it fact the request succeeded in reaching and being processed by the `dwn-server` but the
  embedded DWN instance returned an error status code.
- Now an error HTTP status code is ONLY returned in the event that there is an internal error in the `dwn-server`.  These
  include:
    - `400 Bad Request`: `dwn-request` header missing
    - `400 Bad Request`: `dwn-request` header present but parsing failed
    - `500 Internal Server Error`: Unexpected exception thrown by `dwn.processMessage()`

---

### 2. Tests close HTTP server even in the event of an assertion failure

Previously, many of the `http-api.ts` test cases started an HTTP server:
```typescript
const server = httpApi.listen(3000);
```

At the end of each of the tests (6 total), server instance methods were called to shutdown:
```typescript
server.close();
server.closeAllConnections();
```

When an assertion fails, it throws an error, and the execution of the current function is stopped immediately.
This means that if an assertion fails before the server.close() and server.closeAllConnections() calls, those calls
are never reached and thus never executed.  As a result, subsequent tests would report an `EADDRINUSE` error because
the prior test's server was still listening on port 3000.

This PR modifies the tests to create a new server before each test starts using the `beforeEach()` hook.
The execution of `close()` and `closeAllConnections()` is placed in the `afterEach()` hook, which is executed after each
test, regardless of whether it passed or failed.  This all reduces the duplicative code needed for each test.