### PR TITLE
Tombstones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "dwn-server",
             "version": "0.0.2",
             "dependencies": {
-                "@tbd54566975/dwn-sdk-js": "0.0.32",
+                "@tbd54566975/dwn-sdk-js": "0.0.33",
                 "bytes": "3.1.2",
                 "cors": "2.8.5",
                 "express": "4.18.2",
@@ -326,9 +326,9 @@
             "integrity": "sha512-aWItSZvJj4+GI6FWkjZR13xPNPctq2RRakzo+O6vN7bC2yjwdg5EFpgaSAUn95b7BGSgcflvzVDPoKmJv24IOg=="
         },
         "node_modules/@tbd54566975/dwn-sdk-js": {
-            "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.32.tgz",
-            "integrity": "sha512-SijEHpmJDa0I9hC7jn/8P7XeYeFAi9byMc+b36yuCPDiF+j/hLLYGMpZpnbylJ6+ldWqWWEunumeWjxU4zrc3g==",
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.33.tgz",
+            "integrity": "sha512-ZdQtRTd0M2VcgGli7kDzkePsuxpwiOg+PRsBJ/UPC5fc6oflzbRqV6Lg9v8bWHozjdnijP58J3RMWmf4cj7bWw==",
             "dependencies": {
                 "@ipld/dag-cbor": "9.0.0",
                 "@js-temporal/polyfill": "0.4.3",
@@ -5891,9 +5891,9 @@
             "integrity": "sha512-aWItSZvJj4+GI6FWkjZR13xPNPctq2RRakzo+O6vN7bC2yjwdg5EFpgaSAUn95b7BGSgcflvzVDPoKmJv24IOg=="
         },
         "@tbd54566975/dwn-sdk-js": {
-            "version": "0.0.32",
-            "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.32.tgz",
-            "integrity": "sha512-SijEHpmJDa0I9hC7jn/8P7XeYeFAi9byMc+b36yuCPDiF+j/hLLYGMpZpnbylJ6+ldWqWWEunumeWjxU4zrc3g==",
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.33.tgz",
+            "integrity": "sha512-ZdQtRTd0M2VcgGli7kDzkePsuxpwiOg+PRsBJ/UPC5fc6oflzbRqV6Lg9v8bWHozjdnijP58J3RMWmf4cj7bWw==",
             "requires": {
                 "@ipld/dag-cbor": "9.0.0",
                 "@js-temporal/polyfill": "0.4.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "version": "0.0.2",
     "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.0.32",
+        "@tbd54566975/dwn-sdk-js": "0.0.33",
         "bytes": "3.1.2",
         "node-fetch": "3.3.1",
         "cors": "2.8.5",

--- a/src/json-rpc-handlers/dwn/process-message.ts
+++ b/src/json-rpc-handlers/dwn/process-message.ts
@@ -15,10 +15,10 @@ export const handleDwnProcessMessage: JsonRpcHandler = async (dwnRequest, contex
     let reply;
     const messageType = message?.descriptor?.interface + message?.descriptor?.method;
 
-    // When a record is deleted, the initial RecordsWrite is kept as a tombstone _in addition_ to the RecordsDelete message.
-    // the data associated to that initial RecordsWrite is deleted. If a record was written _and_ deleted before it ever got
-    // to dwn-server, we end up in a situation where we still need to process the tombstone so that we can process the
-    // RecordsDelete. This
+    // When a record is deleted via `RecordsDelete`, the initial RecordsWrite is kept as a tombstone _in addition_
+    // to the RecordsDelete message. the data associated to that initial RecordsWrite is deleted. If a record was written
+    // _and_ deleted before it ever got to dwn-server, we end up in a situation where we still need to process the tombstone
+    // so that we can process the RecordsDelete.
     if (messageType === DwnInterfaceName.Records + DwnMethodName.Write && !dataStream) {
       reply = await dwn.synchronizePrunedInitialRecordsWrite(target, message);
     } else {

--- a/src/json-rpc-handlers/dwn/process-message.ts
+++ b/src/json-rpc-handlers/dwn/process-message.ts
@@ -2,17 +2,29 @@ import type { Readable as IsomorphicReadable } from 'readable-stream';
 import type { JsonRpcHandler, HandlerResponse } from '../../lib/json-rpc-router.js';
 
 import { v4 as uuidv4 } from 'uuid';
+import { DwnInterfaceName, DwnMethodName } from '@tbd54566975/dwn-sdk-js';
 
 import { JsonRpcErrorCodes, createJsonRpcErrorResponse, createJsonRpcSuccessResponse } from '../../lib/json-rpc.js';
 
 export const handleDwnProcessMessage: JsonRpcHandler = async (dwnRequest, context) => {
   let { dwn, dataStream } = context;
   const { target, message } = dwnRequest.params;
-
   const requestId = dwnRequest.id ?? uuidv4();
 
   try {
-    const reply = await dwn.processMessage(target, message, dataStream as IsomorphicReadable);
+    let reply;
+    const messageType = message?.descriptor?.interface + message?.descriptor?.method;
+
+    // When a record is deleted, the initial RecordsWrite is kept as a tombstone _in addition_ to the RecordsDelete message.
+    // the data associated to that initial RecordsWrite is deleted. If a record was written _and_ deleted before it ever got
+    // to dwn-server, we end up in a situation where we still need to process the tombstone so that we can process the
+    // RecordsDelete. This
+    if (messageType === DwnInterfaceName.Records + DwnMethodName.Write && !dataStream) {
+      reply = await dwn.synchronizePrunedInitialRecordsWrite(target, message);
+    } else {
+      reply = await dwn.processMessage(target, message, dataStream as IsomorphicReadable);
+    }
+
 
     // RecordsRead messages return record data as a stream to for accommodate large amounts of data
     let recordDataStream;

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -59,7 +59,7 @@ describe('http api', function() {
     const alice = await createProfile();
     const { recordsWrite, dataStream } = await createRecordsWriteMessage(alice);
 
-    // bork the message
+    // Intentionally delete a required property to produce an invalid RecordsWrite message.
     const message = recordsWrite.toJSON();
     delete message['descriptor']['interface'];
 
@@ -71,7 +71,7 @@ describe('http api', function() {
 
     const dataBytes = await DataStream.toBytes(dataStream);
 
-    // Attempt an initial RecordsWrite with the borked message to ensure the DWN returns an error.
+    // Attempt an initial RecordsWrite with the invalid message to ensure the DWN returns an error.
     let responseInitialWrite = await fetch('http://localhost:3000', {
       method  : 'POST',
       headers : {


### PR DESCRIPTION
When a record is deleted via `RecordsDelete`, the initial `RecordsWrite` is kept as a tombstone _in addition_
to the `RecordsDelete` message. The data associated to that initial `RecordsWrite` is deleted. If a record was written
_and_ deleted before it ever got to `dwn-server`, we end up in a situation where we still need to process the tombstone
so that we can process the `RecordsDelete`. This can and does happen when syncing.

This PR introduces the ability to process `RecordsWrite` messages with no associated data. 