### PR TITLE
DEST Records Read

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "aaron-bond.better-comments",
+    "ambar.bundle-size",
+    "dbaeumer.vscode-eslint",
+    "eamodio.gitlens",
+    "christian-kohler.npm-intellisense",
+    "christian-kohler.path-intellisense"
+  ]
+}

--- a/examples/browser/index.html
+++ b/examples/browser/index.html
@@ -15,6 +15,7 @@
       <button class="button" id="chonker_btn">Upload Large Image</button>
     </div>
     <div id="large_image_display"></div>
+    <img id="image_element" />
   </div>
 
 
@@ -57,7 +58,8 @@
       const iterableStreamReader = iterableReader(streamReader);
 
       const record = await RecordsWrite.create({
-        schema: 'test',
+        schema: 'urn://test',
+        published: true,
         dataCid: await Cid.computeDagPbCidFromStream(iterableStreamReader),
         dataSize: chonker.files[0].size,
         dataFormat: 'application/json',
@@ -84,7 +86,7 @@
 
       const resp = await fetch('http://localhost:3000', options)
       const result = await resp.json();
-
+      document.getElementById('image_element').src = `http://localhost:3000/${did}/records/${record.message.recordId}`
       console.log(result);
     });
   </script>

--- a/examples/dest/index.html
+++ b/examples/dest/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Web5 Feature Testing</title>
+</head>
+
+<body>
+  <input id="file_input"  type="file" accept=".jpg, .jpeg, .gif, .png">
+  
+  <div>
+    <img id="image_element" />
+  </div>
+  
+  <script src="./index.js" type="module"></script>
+</body>
+
+</html>

--- a/examples/dest/index.js
+++ b/examples/dest/index.js
@@ -1,0 +1,71 @@
+
+import { Web5 } from 'https://cdn.jsdelivr.net/npm/@tbd54566975/web5@0.7.6/dist/browser.mjs';
+
+const attributes = ['src', 'href', 'data'];
+const splitDRL = /^(.*?)\/(.*)$/;
+
+function detectMutation(element){
+  console.log(element);
+  const attribute = attributes.find(attr => {
+    return element?.[attr]?.startsWith('did:') ? attr : null;
+  });
+  if (attribute) handleMutation(attribute, element);
+}
+
+async function handleMutation(attribute, element){
+  const [_, did, path] = element[attribute]?.split(splitDRL) || [];
+  if (did && path) {
+    const response = await Web5.did.resolve(did);
+    const nodes = response?.didDocument?.service?.find(service => service.type === 'DecentralizedWebNode')?.serviceEndpoint.nodes;
+    element[attribute] = `${nodes[0].replace(/\/$/, '')}/${did}/${path}`;
+  }
+}
+
+document.addEventListener('DOMContentLoaded', e => {
+  const elements = document.querySelectorAll('[' + attributes.join('], [') + ']');
+  for (const element of elements) {
+    detectMutation(element);
+  }
+});
+
+(new MutationObserver(mutationsList => {
+  for (const mutation of mutationsList) {
+    detectMutation(mutation.target);
+  }
+})).observe(document, {
+  subtree         : true,
+  attributes      : true,
+  attributeFilter : attributes,
+});
+
+/* TEST PAGE CODE */
+
+const { web5, did } = await Web5.connect({
+  techPreview: {
+    dwnEndpoints: ['http://localhost:3000'],
+  }
+});
+
+console.log(did);
+
+if (localStorage.lastImageId) {
+  image_element.setAttribute('src', did + '/records/' + localStorage.lastImageId);
+}
+
+file_input.addEventListener('change', async e => {
+  console.log(e);
+  const file = e.target?.files?.[0];
+  if (file) {
+    const { record } = await web5.dwn.records.create({
+      data    : file,
+      message : {
+        published  : true,
+        dataFormat : file.type
+      }
+    });
+
+    localStorage.lastImageId = record.id;
+
+    console.log(record);
+  }
+});

--- a/examples/dest/index.js
+++ b/examples/dest/index.js
@@ -96,7 +96,7 @@ console.log(did);
 watchDom(web5);
 
 if (localStorage.lastImageId) {
-  image_element.setAttribute('src', did + '/records/' + localStorage.lastImageId);
+  image_element.setAttribute('src', `http://localhost:3000/${did}/records/${localStorage.lastImageId}`);
 }
 
 file_input.addEventListener('change', async e => {

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -59,8 +59,8 @@ export class HttpApi {
       }
     });
 
-    this.api.get('/:did/records/:recordId', async (req, res) => {
-      const record = await RecordsRead.create({ recordId: req.params.recordId });
+    this.api.get('/:did/records/:id', async (req, res) => {
+      const record = await RecordsRead.create({ recordId: req.params.id });
       let reply = await this.dwn.processMessage(req.params.did, record.toJSON()) as RecordsReadReply;
 
       if (reply.status.code === 200) {

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -8,7 +8,7 @@ import express from 'express';
 import { register, Histogram } from 'prom-client';
 
 import { v4 as uuidv4 } from 'uuid';
-import { RecordsRead, RecordsQuery } from '@tbd54566975/dwn-sdk-js';
+import { RecordsRead } from '@tbd54566975/dwn-sdk-js';
 
 import { jsonRpcApi } from './json-rpc-api.js';
 import {
@@ -60,36 +60,28 @@ export class HttpApi {
     });
 
     this.api.get('/:did/records/:recordId', async (req, res) => {
-      // return a plain text string
-      const record = await RecordsRead.create({
-        recordId: req.params.recordId
-      });
+      const record = await RecordsRead.create({ recordId: req.params.recordId });
       let reply = await this.dwn.processMessage(req.params.did, record.toJSON()) as RecordsReadReply;
 
-      if (reply?.record?.data) {
-        const stream = reply.record.data;
-        console.log(stream);
-        delete reply.record.data;
-        res.setHeader('content-type', reply.record.descriptor.dataFormat);
-        res.setHeader('dwn-response', JSON.stringify(reply));
-        return stream.pipe(res);
-      } else {
-        return res.sendStatus(400);
-      }
-    });
+      if (reply.status.code === 200) {
+        if (reply?.record?.data) {
+          const stream = reply.record.data;
+          delete reply.record.data;
 
-    // this.api.get('/:did/records', async (req: Request, res) => {
-    //   const record = await RecordsQuery.create({
-    //     filter: req.query
-    //   });
-    //   const reply = await this.dwn.processMessage(req.params.did, record.toJSON());
-    //   if (reply.entries) {
-    //     res.setHeader('content-type', 'application/json');
-    //     return reply;
-    //   } else {
-    //     return res.sendStatus(400);
-    //   }
-    // });
+          res.setHeader('content-type', reply.record.descriptor.dataFormat);
+          res.setHeader('dwn-response', JSON.stringify(reply));
+
+          return stream.pipe(res);
+        } else {
+          return res.sendStatus(400);
+        }
+      } else if (reply.status.code === 401) {
+        return res.sendStatus(404);
+      } else {
+        return res.status(reply.status.code).send(reply);
+      }
+
+    });
 
     this.api.get('/', (_req, res) => {
       // return a plain text string

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -61,13 +61,10 @@ export class HttpApi {
 
     this.api.get('/:did/records/:recordId', async (req, res) => {
       // return a plain text string
-      console.log(this.dwn);
       const record = await RecordsRead.create({
         recordId: req.params.recordId
       });
       let reply = await this.dwn.processMessage(req.params.did, record.toJSON()) as RecordsReadReply;
-
-      console.log(reply);
 
       if (reply?.record?.data) {
         const stream = reply.record.data;
@@ -81,18 +78,18 @@ export class HttpApi {
       }
     });
 
-    this.api.get('/:did/records', async (req: Request, res) => {
-      const record = await RecordsQuery.create({
-        filter: req.query
-      });
-      const reply = await this.dwn.processMessage(req.params.did, record.toJSON());
-      if (reply.entries) {
-        res.setHeader('content-type', 'application/json');
-        return reply;
-      } else {
-        return res.sendStatus(400);
-      }
-    });
+    // this.api.get('/:did/records', async (req: Request, res) => {
+    //   const record = await RecordsQuery.create({
+    //     filter: req.query
+    //   });
+    //   const reply = await this.dwn.processMessage(req.params.did, record.toJSON());
+    //   if (reply.entries) {
+    //     res.setHeader('content-type', 'application/json');
+    //     return reply;
+    //   } else {
+    //     return res.sendStatus(400);
+    //   }
+    // });
 
     this.api.get('/', (_req, res) => {
       // return a plain text string

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -81,21 +81,18 @@ export class HttpApi {
       }
     });
 
-    // this.api.get('/:did/records', async (req: Request, res) => {
-    //   let reply = await this.dwn.processMessage(req.params.did, await RecordsQuery.create({
-    //     filter: req.query as any
-    //   }));
-
-    //   if (reply?.record?.data) {
-    //     const stream = reply.record.data;
-    //     delete reply.record.data;
-    //     res.setHeader('content-type', reply.record.descriptor.dataFormat);
-    //     res.setHeader('dwn-response', JSON.stringify(reply));
-    //     return stream.pipe(res);
-    //   } else {
-    //     return res.sendStatus(400);
-    //   }
-    // });
+    this.api.get('/:did/records', async (req: Request, res) => {
+      const record = await RecordsQuery.create({
+        filter: req.query
+      });
+      const reply = await this.dwn.processMessage(req.params.did, record.toJSON());
+      if (reply.entries) {
+        res.setHeader('content-type', 'application/json');
+        return reply;
+      } else {
+        return res.sendStatus(400);
+      }
+    });
 
     this.api.get('/', (_req, res) => {
       // return a plain text string

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -338,4 +338,106 @@ describe('http api', function() {
       expect(cid).to.equal(expectedCid);
     });
   });
+
+  describe('/:did/records/:recordId', function () {
+    it('returns record data if record is published', async function () {
+      const filePath = './fixtures/test.jpeg';
+      const { cid: expectedCid, size, stream } = await getFileAsReadStream(filePath);
+
+      const alice = await createProfile();
+      const { recordsWrite } = await createRecordsWriteMessage(alice, {
+        dataCid   : expectedCid,
+        dataSize  : size,
+        published : true
+      });
+
+      let requestId = uuidv4();
+      let dwnRequest = createJsonRpcRequest(requestId, 'dwn.processMessage', {
+        message : recordsWrite.toJSON(),
+        target  : alice.did,
+      });
+
+      let response = await fetch('http://localhost:3000', {
+        method  : 'POST',
+        headers : {
+          'dwn-request': JSON.stringify(dwnRequest)
+        },
+        body: stream
+      });
+
+      expect(response.status).to.equal(200);
+
+      const body = await response.json() as JsonRpcResponse;
+      expect(body.id).to.equal(requestId);
+      expect(body.error).to.not.exist;
+
+      const { reply } = body.result;
+      expect(reply.status.code).to.equal(202);
+
+      response = await fetch(`http://localhost:3000/${alice.did}/records/${recordsWrite.message.recordId}`);
+      const blob = await response.blob();
+
+      expect(blob.size).to.equal(size);
+    });
+
+    it('returns a 404 if an unpublished record is requested', async function () {
+      const filePath = './fixtures/test.jpeg';
+      const { cid: expectedCid, size, stream } = await getFileAsReadStream(filePath);
+
+      const alice = await createProfile();
+      const { recordsWrite } = await createRecordsWriteMessage(alice, {
+        dataCid  : expectedCid,
+        dataSize : size,
+      });
+
+      let requestId = uuidv4();
+      let dwnRequest = createJsonRpcRequest(requestId, 'dwn.processMessage', {
+        message : recordsWrite.toJSON(),
+        target  : alice.did,
+      });
+
+      let response = await fetch('http://localhost:3000', {
+        method  : 'POST',
+        headers : {
+          'dwn-request': JSON.stringify(dwnRequest)
+        },
+        body: stream
+      });
+
+      expect(response.status).to.equal(200);
+
+      const body = await response.json() as JsonRpcResponse;
+      expect(body.id).to.equal(requestId);
+      expect(body.error).to.not.exist;
+
+      const { reply } = body.result;
+      expect(reply.status.code).to.equal(202);
+
+      response = await fetch(`http://localhost:3000/${alice.did}/records/${recordsWrite.message.recordId}`);
+
+      expect(response.status).to.equal(404);
+    });
+
+    it('returns a 404 if record doesnt exist', async function () {
+      const alice = await createProfile();
+      const { recordsWrite } = await createRecordsWriteMessage(alice);
+
+      const response = await fetch(`http://localhost:3000/${alice.did}/records/${recordsWrite.message.recordId}`);
+      expect(response.status).to.equal(404);
+    });
+
+    it('returns a 404 for invalid did', async function () {
+      const alice = await createProfile();
+      const { recordsWrite } = await createRecordsWriteMessage(alice);
+
+      const response = await fetch(`http://localhost:3000/1234567892345678/records/${recordsWrite.message.recordId}`);
+      expect(response.status).to.equal(404);
+    });
+
+    it('returns a 404 for invalid record id', async function () {
+      const alice = await createProfile();
+      const response = await fetch(`http://localhost:3000/${alice.did}/records/kaka`);
+      expect(response.status).to.equal(404);
+    });
+  });
 });

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -339,7 +339,7 @@ describe('http api', function() {
     });
   });
 
-  describe('/:did/records/:recordId', function () {
+  describe('/:did/records/:id', function () {
     it('returns record data if record is published', async function () {
       const filePath = './fixtures/test.jpeg';
       const { cid: expectedCid, size, stream } = await getFileAsReadStream(filePath);


### PR DESCRIPTION
this PR adds an http endpoint `GET /dwn/:did/records/:record-id` that can be used to get the data associated to a _published_ record. This endpoint requires no authentication or authorization because the author intends for it to be publicly consumable. Example usage has been included in the `examples/dest` directory.

This is the first of many endpoints like this that we intend to introduce to expose a REST-like (aka DEST) api surface for DWNs