### PR TITLE
tag published container images with dwn sdk version as well

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -41,12 +41,21 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
+      
+      - name: Retrieve DWN SDK version
+        run: |
+          echo "dwn_sdk_image_tag=${{ env.REGISTRY }}/${IMAGE_NAME,,}:dwn-sdk-$(jq -r '.dependencies."@tbd54566975/dwn-sdk-js"' package.json)" >> $GITHUB_OUTPUT
+        id: dwn_sdk_version
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+      
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
           file: Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.dwn_sdk_version.outputs.dwn_sdk_image_tag }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This will create images named `ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.0.35` in addition to the current image tags. The DWN SDK version is extracted from `package.json`.

[Sample run here](https://github.com/TBD54566975/dwn-server/actions/runs/5720527169/job/15500612907)