### PR TITLE
adding subscription handling to dwn server.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,4 +22,8 @@ export const config = {
 
   // log level - trace/debug/info/warn/error
   logLevel: process.env.DWN_SERVER_LOG_LEVEL || 'INFO',
+
+  subscriptionsEnabled:
+    { on: true, off: false }[process.env.SUBSCRIPTIONS] ?? true,
+  // where to store persistant data
 };

--- a/src/json-rpc-handlers/dwn/process-message.ts
+++ b/src/json-rpc-handlers/dwn/process-message.ts
@@ -36,7 +36,6 @@ export const handleDwnProcessMessage: JsonRpcHandler = async (
       messageType === DwnInterfaceName.Records + DwnMethodName.Write &&
       !dataStream
     ) {
-      console.log('sending');
       reply = await dwn.synchronizePrunedInitialRecordsWrite(target, message);
     } else if (
       messageType ===

--- a/src/json-rpc-handlers/dwn/process-message.ts
+++ b/src/json-rpc-handlers/dwn/process-message.ts
@@ -36,6 +36,7 @@ export const handleDwnProcessMessage: JsonRpcHandler = async (
       messageType === DwnInterfaceName.Records + DwnMethodName.Write &&
       !dataStream
     ) {
+      console.log('sending');
       reply = await dwn.synchronizePrunedInitialRecordsWrite(target, message);
     } else if (
       messageType ===

--- a/src/lib/json-rpc-router.ts
+++ b/src/lib/json-rpc-router.ts
@@ -1,11 +1,16 @@
+import type { JsonRpcRequest, JsonRpcResponse } from './json-rpc.js';
+
 import type { Dwn } from '@tbd54566975/dwn-sdk-js';
 import type { Readable } from 'node:stream';
-import type { JsonRpcRequest, JsonRpcResponse } from './json-rpc.js';
+import type { SubscriptionController } from '../subscription-manager.js';
+import type { WebSocket } from 'ws';
 
 export type RequestContext = {
   dwn: Dwn;
   transport: 'http' | 'ws';
   dataStream?: Readable;
+  socket?: WebSocket;
+  subscriptionManager?: SubscriptionController;
 };
 
 export type HandlerResponse = {

--- a/src/subscription-manager.ts
+++ b/src/subscription-manager.ts
@@ -1,0 +1,174 @@
+import type { Dwn, SubscriptionFilter } from '@tbd54566975/dwn-sdk-js';
+import type { EventMessage, PermissionsGrant } from '@tbd54566975/dwn-sdk-js';
+import type {
+  MessageStore,
+  SubscriptionRequestReply,
+} from '@tbd54566975/dwn-sdk-js';
+
+import type { JsonRpcSuccessResponse } from './lib/json-rpc.js';
+import { SubscriptionRequest } from '@tbd54566975/dwn-sdk-js';
+import type WebSocket from 'ws';
+import { WebSocketServer } from 'ws';
+import { v4 as uuidv4 } from 'uuid';
+
+export class Subscription {
+  from?: string;
+  subscriptionId: string;
+  createdAt: string;
+  description: string;
+  filters?: SubscriptionFilter[];
+  permissionGrant: PermissionsGrant;
+  connection: WebSocket;
+}
+
+export interface SubscriptionController {
+  clear(): Promise<void>;
+  close(): Promise<void>;
+  start(): Promise<void>;
+  subscribe(
+    request: RegisterSubscriptionRequest,
+  ): Promise<RegisterSubscriptionReply>;
+}
+
+export type RegisterSubscriptionRequest = {
+  from: string;
+  socket: WebSocket;
+  filters?: SubscriptionFilter[];
+  permissionGrant: PermissionsGrant;
+  subscriptionRequestMessage: SubscriptionRequest;
+};
+
+export type RegisterSubscriptionReply = {
+  reply: SubscriptionRequestReply;
+  subscriptionId?: string;
+};
+
+export type defaultSubscriptionChannel = 'event';
+
+export type SubscriptionManagerOptions = {
+  subscriptionChannel: string;
+  wss: WebSocketServer;
+  dwn: Dwn;
+  messageStore: MessageStore;
+  tenant: string;
+};
+
+export class SubscriptionManager {
+  private wss: WebSocketServer;
+  private dwn: Dwn;
+  private connections: Map<string, Subscription>;
+  private messageStore: MessageStore;
+  private tenant: string;
+  options: SubscriptionManagerOptions;
+  #open: boolean;
+
+  constructor(options?: SubscriptionManagerOptions) {
+    this.wss = options?.wss || new WebSocketServer();
+    this.connections = new Map();
+    this.messageStore = options?.messageStore;
+    this.tenant = options?.tenant;
+    this.dwn = options?.dwn;
+    this.options = options;
+
+    this.wss.on('connection', (socket: WebSocket) => {
+      socket.on('subscribe', async (data) => {
+        await this.handleSubscribe(socket, data);
+      });
+    });
+  }
+
+  async clear(): Promise<void> {
+    this.wss.removeAllListeners();
+    this.connections.clear();
+  }
+
+  async close(): Promise<void> {
+    this.#open = false;
+    this.connections.clear();
+    this.wss.close();
+  }
+
+  async open(): Promise<void> {
+    this.#open = true;
+  }
+
+  async start(): Promise<void> {
+    this.open();
+  }
+
+  private async createSubscription(
+    from: string,
+    request: RegisterSubscriptionRequest,
+  ): Promise<Subscription> {
+    return {
+      from,
+      subscriptionId: uuidv4(),
+      createdAt: new Date().toISOString(),
+      description: 'subscription',
+      filters: request.filters,
+      permissionGrant: request.permissionGrant,
+      connection: request.socket,
+    };
+  }
+
+  async handleSubscribe(
+    socket: WebSocket,
+    data: any,
+  ): Promise<RegisterSubscriptionReply> {
+    // parse message
+    const req = SubscriptionRequest.parse(data);
+    return await this.subscribe(req, socket);
+  }
+
+  createJSONRPCEvent(e: EventMessage): JsonRpcSuccessResponse {
+    return {
+      id: uuidv4(),
+      jsonrpc: '2.0',
+      result: e,
+    };
+  }
+
+  async subscribe(
+    req: RegisterSubscriptionRequest,
+    socket: WebSocket,
+  ): Promise<RegisterSubscriptionReply> {
+    const subscriptionReply = await this.dwn.handleSubscriptionRequest(
+      this.tenant,
+      req.subscriptionRequestMessage,
+    );
+    if (subscriptionReply.status.code !== 200) {
+      return { reply: subscriptionReply };
+    }
+    const subscription = await this.createSubscription(req.from, req);
+    this.registerSubscription(subscription);
+    // set up forwarding.
+    subscriptionReply.subscription.emitter.on(
+      async (e: EventMessage): Promise<void> => {
+        const jsonRpcResponse = this.createJSONRPCEvent(e);
+        const str = JSON.stringify(jsonRpcResponse);
+        return socket.send(Buffer.from(str));
+      },
+    );
+  }
+
+  private async registerSubscription(
+    subscription: Subscription,
+  ): Promise<void> {
+    if (!this.#open) {
+      throw new Error("Can't register subscription. It's not opened.");
+    }
+    if (this.connections.has(subscription.subscriptionId)) {
+      throw new Error(
+        'Failed to add connection to controller. ID already exists.',
+      );
+    }
+    this.connections.set(subscription.subscriptionId, subscription);
+    subscription.connection.on('close', () => {
+      this.deleteSubscription(subscription.subscriptionId);
+    });
+  }
+
+  private async deleteSubscription(id: string): Promise<void> {
+    this.connections.delete(id);
+  }
+}

--- a/src/subscription-manager.ts
+++ b/src/subscription-manager.ts
@@ -2,7 +2,6 @@ import type { Dwn, SubscriptionFilter } from '@tbd54566975/dwn-sdk-js';
 import type { EventMessage, PermissionsGrant } from '@tbd54566975/dwn-sdk-js';
 
 import type { JsonRpcSuccessResponse } from './lib/json-rpc.js';
-import type { MessageStore } from '@tbd54566975/dwn-sdk-js';
 import { SubscriptionRequest } from '@tbd54566975/dwn-sdk-js';
 import type { SubscriptionRequestReply } from '@tbd54566975/dwn-sdk-js';
 import type WebSocket from 'ws';
@@ -46,7 +45,6 @@ export type defaultSubscriptionChannel = 'event';
 export type SubscriptionManagerOptions = {
   wss?: WebSocketServer;
   dwn: Dwn;
-  messageStore: MessageStore;
   tenant: string;
 };
 
@@ -54,7 +52,6 @@ export class SubscriptionManager {
   private wss: WebSocketServer;
   private dwn: Dwn;
   private connections: Map<string, Subscription>;
-  private messageStore: MessageStore;
   private tenant: string;
   options: SubscriptionManagerOptions;
   #open: boolean;
@@ -62,13 +59,14 @@ export class SubscriptionManager {
   constructor(options?: SubscriptionManagerOptions) {
     this.wss = options?.wss || new WebSocketServer();
     this.connections = new Map();
-    this.messageStore = options?.messageStore;
     this.tenant = options?.tenant;
     this.dwn = options?.dwn;
     this.options = options;
 
     this.wss.on('connection', (socket: WebSocket) => {
-      socket.on('subscribe', async (data) => {
+      console.log('connected');
+      socket.on('message', async (data) => {
+        console.log('got message...');
         await this.handleSubscribe(socket, data);
       });
     });

--- a/src/subscription-manager.ts
+++ b/src/subscription-manager.ts
@@ -137,8 +137,10 @@ export class SubscriptionManager {
     const subscription = await this.createSubscription(req.from, req);
     this.registerSubscription(subscription);
     // set up forwarding.
+    //  console.log('---------', subscriptionReply.subscription.emitter);
     subscriptionReply.subscription.emitter.on(
       async (e: EventMessage): Promise<void> => {
+        // console.log('got a record', e);
         const jsonRpcResponse = this.createJSONRPCEvent(e);
         const str = JSON.stringify(jsonRpcResponse);
         return req.socket.send(Buffer.from(str));

--- a/src/ws-api.ts
+++ b/src/ws-api.ts
@@ -50,6 +50,7 @@ export class WsApi {
    */
   #handleConnection(socket: WebSocket, _request: IncomingMessage): void {
     const dwn = this.dwn;
+    const subscriptionManager = this.#subscriptionManager;
 
     socket[SOCKET_ISALIVE_SYMBOL] = true;
 
@@ -107,6 +108,8 @@ export class WsApi {
         dwn,
         transport: 'ws',
         dataStream: requestDataStream,
+        subscriptionManager: subscriptionManager,
+        socket: socket,
       };
 
       const { jsonRpcResponse } = await jsonRpcApi.handle(

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -1,3 +1,31 @@
+import {
+  Cid,
+  DataStream,
+  RecordsQuery,
+  RecordsRead,
+} from '@tbd54566975/dwn-sdk-js';
+import {
+  JsonRpcErrorCodes,
+  createJsonRpcRequest,
+} from '../src/lib/json-rpc.js';
+import type {
+  JsonRpcErrorResponse,
+  JsonRpcResponse,
+} from '../src/lib/json-rpc.js';
+import { clear as clearDwn, dwn } from './test-dwn.js';
+import {
+  createProfile,
+  createRecordsWriteMessage,
+  getFileAsReadStream,
+  streamHttpRequest,
+} from './utils.js';
+
+import { HttpApi } from '../src/http-api.js';
+import type { Server } from 'http';
+import { expect } from 'chai';
+import fetch from 'node-fetch';
+import request from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
 // node.js 18 and earlier,  needs globalThis.crypto polyfill
 import { webcrypto } from 'node:crypto';
 
@@ -5,36 +33,6 @@ if (!globalThis.crypto) {
   // @ts-ignore
   globalThis.crypto = webcrypto;
 }
-
-import type { Server } from 'http';
-import type {
-  JsonRpcErrorResponse,
-  JsonRpcResponse,
-} from '../src/lib/json-rpc.js';
-
-import fetch from 'node-fetch';
-import request from 'supertest';
-
-import { expect } from 'chai';
-import { HttpApi } from '../src/http-api.js';
-import { v4 as uuidv4 } from 'uuid';
-import {
-  Cid,
-  DataStream,
-  RecordsQuery,
-  RecordsRead,
-} from '@tbd54566975/dwn-sdk-js';
-import { clear as clearDwn, dwn } from './test-dwn.js';
-import {
-  createJsonRpcRequest,
-  JsonRpcErrorCodes,
-} from '../src/lib/json-rpc.js';
-import {
-  createProfile,
-  createRecordsWriteMessage,
-  getFileAsReadStream,
-  streamHttpRequest,
-} from './utils.js';
 
 describe('http api', function () {
   let httpApi: HttpApi;

--- a/tests/subscription-manager.spec.ts
+++ b/tests/subscription-manager.spec.ts
@@ -1,44 +1,110 @@
-import { assert } from 'chai';
-import { createProfile } from './utils.js';
+import http from 'node:http';
+import { WebSocket, type WebSocketServer } from 'ws';
+
+import {
+  DataStoreLevel,
+  DidKeyResolver,
+  Dwn,
+  EventLogLevel,
+  MessageStoreLevel,
+  SubscriptionRequest,
+} from '@tbd54566975/dwn-sdk-js';
+
 import { Jws } from '@tbd54566975/dwn-sdk-js';
 import type { SubscriptionController } from '../src/subscription-manager.js';
 import { SubscriptionManager } from '../src/subscription-manager.js';
+import { assert } from 'chai';
+import { createProfile } from './utils.js';
+import type { Profile } from './utils.js';
+import { WsApi } from '../src/ws-api.js';
 
-describe('Subscription Manager Test', () => {
+describe('Subscription Manager Test', async () => {
   let subscriptionManager: SubscriptionController;
+  let wsServer: WebSocketServer;
+  let server: http.Server;
+  let dataStore: DataStoreLevel;
+  let eventLog: EventLogLevel;
+  let messageStore: MessageStoreLevel;
+  let alice: Profile;
+  let dwn: Dwn;
+  let socket: WebSocket;
 
-  // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
-  // so that different test suites can reuse the same backend store for testing
   before(async () => {
-    subscriptionManager = new SubscriptionManager({});
+    // Setup data stores...
+    dataStore = new DataStoreLevel({
+      blockstoreLocation: 'data/DATASTORE',
+    });
+    eventLog = new EventLogLevel({ location: 'data/EVENTLOG' });
+    messageStore = new MessageStoreLevel({
+      blockstoreLocation: 'data/MESSAGESTORE',
+      indexLocation: 'data/INDEX',
+    });
+
+    // create profile
+    alice = await createProfile();
+    // create Dwn
+    dwn = await Dwn.create({ eventLog, dataStore, messageStore });
+
+    // create listeners...
+    server = http.createServer();
+    server.listen(9002, '127.0.0.1');
+    const wsApi = new WsApi(server, dwn);
+    wsServer = wsApi.start();
+
+    // create subscription manager...
+    subscriptionManager = new SubscriptionManager({
+      dwn: dwn,
+      messageStore: messageStore,
+      tenant: alice.did,
+      wss: wsServer,
+    });
+    return;
   });
 
   // before each, clear the subscriptions
   beforeEach(async () => {
     subscriptionManager.clear();
+    await dataStore.clear();
+    await eventLog.clear();
+    await messageStore.clear();
   });
 
   // close at the end
   after(async () => {
     await subscriptionManager.close();
+    wsServer.close();
+    server.close();
+    server.closeAllConnections();
+    socket.close();
   });
 
   it('test subscription manager registration', async () => {
     try {
-      const alice = await createProfile();
+      const signer = await DidKeyResolver.generate();
+
+      // create a subscription request
       const req = await SubscriptionRequest.create({
-        filter: {
-          eventType: EventType.Operation,
-        },
-        authorizationSignatureInput: Jws.createSignatureInput(alice),
+        signer: Jws.createSigner(signer),
       });
-      const subscription = await subscriptionManager.subscribe({
-        from: alice.did,
-        subscriptionRequestMessage: req,
-        permissionGrant: 'asdf',
-      });
-      assert.isDefined(subscription.reply);
-      assert.isDefined(subscription.subscriptionId);
+
+      // setup a socket connection to wsServer
+      const socket = new WebSocket(wsServer.address.toString());
+      socket.onopen = async (): Promise<void> => {
+        console.log('sending req', req);
+        // send a subscription request
+        // const subscription = await subscriptionManager.subscribe({
+        //   from: alice.did,
+        //   subscriptionRequestMessage: req,
+        //   permissionGrant: 'asdf',
+        // });
+        socket.send('subscription request');
+        return;
+      };
+
+      socket.onmessage = (event): Promise<void> => {
+        console.log('got message', event);
+        return;
+      };
     } catch (error) {
       assert.fail(error, undefined, 'failed to register subscription');
     }

--- a/tests/subscription-manager.spec.ts
+++ b/tests/subscription-manager.spec.ts
@@ -68,7 +68,10 @@ describe('Subscription Manager Test', async () => {
         // set up lisetner...
         socket.onmessage = (event): Promise<void> => {
           try {
-            console.log('got message');
+            const resp = JSON.parse(event.data.toString());
+            if (resp.error) {
+              throw new Error(resp.error.message);
+            }
             resolve(event);
             return;
           } catch (error) {
@@ -92,6 +95,7 @@ describe('Subscription Manager Test', async () => {
         };
 
         socket.onopen = async (): Promise<void> => {
+          // on open
           const requestId = uuidv4();
           const dwnRequest = createJsonRpcRequest(
             requestId,
@@ -101,6 +105,7 @@ describe('Subscription Manager Test', async () => {
               target: alice.did,
             },
           );
+
           try {
             if (socket.readyState !== WebSocket.OPEN) {
               reject(new Error('socket not open'));

--- a/tests/subscription-manager.spec.ts
+++ b/tests/subscription-manager.spec.ts
@@ -1,0 +1,46 @@
+import { assert } from 'chai';
+import { createProfile } from './utils.js';
+import { Jws } from '@tbd54566975/dwn-sdk-js';
+import type { SubscriptionController } from '../src/subscription-manager.js';
+import { SubscriptionManager } from '../src/subscription-manager.js';
+
+describe('Subscription Manager Test', () => {
+  let subscriptionManager: SubscriptionController;
+
+  // important to follow the `before` and `after` pattern to initialize and clean the stores in tests
+  // so that different test suites can reuse the same backend store for testing
+  before(async () => {
+    subscriptionManager = new SubscriptionManager({});
+  });
+
+  // before each, clear the subscriptions
+  beforeEach(async () => {
+    subscriptionManager.clear();
+  });
+
+  // close at the end
+  after(async () => {
+    await subscriptionManager.close();
+  });
+
+  it('test subscription manager registration', async () => {
+    try {
+      const alice = await createProfile();
+      const req = await SubscriptionRequest.create({
+        filter: {
+          eventType: EventType.Operation,
+        },
+        authorizationSignatureInput: Jws.createSignatureInput(alice),
+      });
+      const subscription = await subscriptionManager.subscribe({
+        from: alice.did,
+        subscriptionRequestMessage: req,
+        permissionGrant: 'asdf',
+      });
+      assert.isDefined(subscription.reply);
+      assert.isDefined(subscription.subscriptionId);
+    } catch (error) {
+      assert.fail(error, undefined, 'failed to register subscription');
+    }
+  });
+});

--- a/tests/test-dwn.ts
+++ b/tests/test-dwn.ts
@@ -1,13 +1,15 @@
 import {
-  Dwn,
   DataStoreLevel,
+  Dwn,
   EventLogLevel,
   MessageStoreLevel,
 } from '@tbd54566975/dwn-sdk-js';
 
-const dataStore = new DataStoreLevel({ blockstoreLocation: 'data/DATASTORE' });
+export const dataStore = new DataStoreLevel({
+  blockstoreLocation: 'data/DATASTORE',
+});
 const eventLog = new EventLogLevel({ location: 'data/EVENTLOG' });
-const messageStore = new MessageStoreLevel({
+export const messageStore = new MessageStoreLevel({
   blockstoreLocation: 'data/MESSAGESTORE',
   indexLocation: 'data/INDEX',
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -12,10 +12,10 @@ import {
   Cid,
   DataStream,
   DidKeyResolver,
-  PrivateKeySigner,
   RecordsWrite,
   SubscriptionRequest,
 } from '@tbd54566975/dwn-sdk-js';
+import { Jws } from '@tbd54566975/dwn-sdk-js';
 
 // __filename and __dirname are not defined in ES module scope
 const __filename = fileURLToPath(import.meta.url);
@@ -32,18 +32,11 @@ export type Profile = {
 
 export async function createProfile(): Promise<Profile> {
   const { did, keyPair, keyId } = await DidKeyResolver.generate();
-
-  // signer is required by all dwn message classes. it's used to sign messages
-  const signer = new PrivateKeySigner({
-    privateJwk: keyPair.privateJwk,
-    algorithm: keyPair.privateJwk.alg,
-    keyId: `${did}#${keyId}`,
-  });
-
+  const signer = Jws.createSigner({ keyPair, keyId });
   return {
-    did,
-    keyPair,
-    signer,
+    did: did,
+    keyPair: keyPair,
+    signer: signer,
   };
 }
 
@@ -76,7 +69,7 @@ export async function createSubscriptionRequest(
 ): Promise<SubscriptionRequest> {
   console.log(overrides);
   const subscriptionRequest = await SubscriptionRequest.create({
-    authorizationSignatureInput: signer.signatureInput,
+    signer: signer.signer,
   });
   return subscriptionRequest;
 }

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -14,6 +14,7 @@ import {
   DidKeyResolver,
   PrivateKeySigner,
   RecordsWrite,
+  SubscriptionRequest,
 } from '@tbd54566975/dwn-sdk-js';
 
 // __filename and __dirname are not defined in ES module scope
@@ -66,6 +67,19 @@ export type GenerateProtocolsConfigureOutput = {
   recordsWrite: RecordsWrite;
   dataStream: Readable | undefined;
 };
+
+export type CreateSubscriptionRequestOverride = {};
+
+export async function createSubscriptionRequest(
+  signer: Profile,
+  overrides: CreateSubscriptionRequestOverride,
+): Promise<SubscriptionRequest> {
+  console.log(overrides);
+  const subscriptionRequest = await SubscriptionRequest.create({
+    authorizationSignatureInput: signer.signatureInput,
+  });
+  return subscriptionRequest;
+}
 
 export async function createRecordsWriteMessage(
   signer: Profile,


### PR DESCRIPTION
Server updates for  [#508](https://github.com/TBD54566975/dwn-sdk-js/pull/508). In draft as [#508](https://github.com/TBD54566975/dwn-sdk-js/pull/508) is still in progress and still working out some kinks. Subscriptions only work on web socket connections. It's a little different than the rest of the processMessage records, as the server has to manage the live socket connection pipes given by the dwn. 

In DRAFT until everything is together and also some of the tests aren't working yet (fixing today).

Do NOT merge yet, but sharing for transparency about direction.