### PR TITLE
Prettier for imports

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,8 +1,6 @@
 {
   "singleQuote": true,
-  "plugins": [
-    "@trivago/prettier-plugin-sort-imports"
-  ],
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
   "importOrder": [
     "^@tbd54566975/(.*)$",
     "<THIRD_PARTY_MODULES>",

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,14 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "plugins": [
+    "@trivago/prettier-plugin-sort-imports"
+  ],
+  "importOrder": [
+    "^@tbd54566975/(.*)$",
+    "<THIRD_PARTY_MODULES>",
+    "^./lib/(.*)$",
+    "^[./]"
+  ],
+  "importOrderCaseInsensitive": true,
+  "importOrderSeparation": true
 }

--- a/examples/node/stream-data.js
+++ b/examples/node/stream-data.js
@@ -1,6 +1,6 @@
-import fetch from 'node-fetch';
-
 import { RecordsRead } from '@tbd54566975/dwn-sdk-js';
+
+import fetch from 'node-fetch';
 import { v4 as uuidv4 } from 'uuid';
 
 import { createJsonRpcRequest } from '../../dist/src/lib/json-rpc.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "ws": "8.12.0"
       },
       "devDependencies": {
+        "@trivago/prettier-plugin-sort-imports": "^4.2.0",
         "@types/bytes": "3.1.1",
         "@types/chai": "4.3.4",
         "@types/express": "4.17.17",
@@ -69,6 +70,378 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.9.4.tgz",
       "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name/node_modules/@babel/types": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
+      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template/node_modules/@babel/types": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.3",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
@@ -905,6 +1278,29 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.2.0.tgz",
+      "integrity": "sha512-YBepjbt+ZNBVmN3ev1amQH3lWCmHyt5qTbLCp/syXJRu/Kw2koXh44qayB1gMRxcL/gV8egmjN5xWSrYyfUtyw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "^7.20.5",
+        "@babel/traverse": "7.17.3",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x - 3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
       }
     },
     "node_modules/@types/body-parser": {
@@ -4683,6 +5079,12 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
+    },
     "node_modules/js-sdsl": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.2.tgz",
@@ -4692,6 +5094,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4709,6 +5117,18 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.0.tgz",
       "integrity": "sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g=="
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -6789,6 +7209,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sparse-array": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
@@ -7184,6 +7613,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ws": "8.12.0"
   },
   "devDependencies": {
+    "@trivago/prettier-plugin-sort-imports": "^4.2.0",
     "@types/bytes": "3.1.1",
     "@types/chai": "4.3.4",
     "@types/express": "4.17.17",

--- a/src/dwn-server.ts
+++ b/src/dwn-server.ts
@@ -1,15 +1,17 @@
 import { Dwn } from '@tbd54566975/dwn-sdk-js';
+
+import type { Server } from 'http';
 import log from 'loglevel';
 import prefix from 'loglevel-plugin-prefix';
-import type { Server } from 'http';
 import { type WebSocketServer } from 'ws';
 
-import { getDWNConfig } from './storage.js';
-import { HttpApi } from './http-api.js';
 import { HttpServerShutdownHandler } from './lib/http-server-shutdown-handler.js';
-import { setProcessHandlers } from './process-handlers.js';
-import { WsApi } from './ws-api.js';
+
 import { type Config, config as defaultConfig } from './config.js';
+import { HttpApi } from './http-api.js';
+import { setProcessHandlers } from './process-handlers.js';
+import { getDWNConfig } from './storage.js';
+import { WsApi } from './ws-api.js';
 
 export type DwnServerOptions = {
   dwn?: Dwn;

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -1,26 +1,26 @@
-import http from 'http';
 import {
   type Dwn,
   RecordsRead,
   type RecordsReadReply,
 } from '@tbd54566975/dwn-sdk-js';
-import type { Express, Request, Response } from 'express';
-
-import type { JsonRpcRequest } from './lib/json-rpc.js';
-import type { RequestContext } from './lib/json-rpc-router.js';
 
 import cors from 'cors';
+import type { Express, Request, Response } from 'express';
 import express from 'express';
+import http from 'http';
 import log from 'loglevel';
-import responseTime from 'response-time';
-
-import { jsonRpcApi } from './json-rpc-api.js';
 import { register } from 'prom-client';
+import responseTime from 'response-time';
 import { v4 as uuidv4 } from 'uuid';
+
+import type { RequestContext } from './lib/json-rpc-router.js';
+import type { JsonRpcRequest } from './lib/json-rpc.js';
 import {
   createJsonRpcErrorResponse,
   JsonRpcErrorCodes,
 } from './lib/json-rpc.js';
+
+import { jsonRpcApi } from './json-rpc-api.js';
 import { requestCounter, responseHistogram } from './metrics.js';
 
 export class HttpApi {

--- a/src/json-rpc-api.ts
+++ b/src/json-rpc-api.ts
@@ -1,5 +1,6 @@
-import { handleDwnProcessMessage } from './json-rpc-handlers/dwn/index.js';
 import { JsonRpcRouter } from './lib/json-rpc-router.js';
+
+import { handleDwnProcessMessage } from './json-rpc-handlers/dwn/index.js';
 
 export const jsonRpcApi = new JsonRpcRouter();
 

--- a/src/json-rpc-handlers/dwn/process-message.ts
+++ b/src/json-rpc-handlers/dwn/process-message.ts
@@ -1,13 +1,13 @@
-import type { Readable as IsomorphicReadable } from 'readable-stream';
 import type { RecordsReadReply } from '@tbd54566975/dwn-sdk-js';
+import { DwnInterfaceName, DwnMethodName } from '@tbd54566975/dwn-sdk-js';
+
+import type { Readable as IsomorphicReadable } from 'readable-stream';
+import { v4 as uuidv4 } from 'uuid';
+
 import type {
   HandlerResponse,
   JsonRpcHandler,
 } from '../../lib/json-rpc-router.js';
-
-import { v4 as uuidv4 } from 'uuid';
-import { DwnInterfaceName, DwnMethodName } from '@tbd54566975/dwn-sdk-js';
-
 import {
   createJsonRpcErrorResponse,
   createJsonRpcSuccessResponse,

--- a/src/lib/json-rpc-router.ts
+++ b/src/lib/json-rpc-router.ts
@@ -1,5 +1,7 @@
 import type { Dwn } from '@tbd54566975/dwn-sdk-js';
+
 import type { Readable } from 'node:stream';
+
 import type { JsonRpcRequest, JsonRpcResponse } from './json-rpc.js';
 
 export type RequestContext = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,12 @@
 // node.js 18 and earlier, needs globalThis.crypto polyfill. needed for dwn-sdk-js
 import { webcrypto } from 'node:crypto';
 
+import { DwnServer } from './dwn-server.js';
+
 if (!globalThis.crypto) {
   // @ts-ignore
   globalThis.crypto = webcrypto;
 }
-
-import { DwnServer } from './dwn-server.js';
 
 const dwnServer = new DwnServer();
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,5 +1,3 @@
-import type { Config } from './config.js';
-import type { Dialect } from '@tbd54566975/dwn-sql-store';
 import {
   DataStoreLevel,
   EventLogLevel,
@@ -11,12 +9,7 @@ import type {
   EventLog,
   MessageStore,
 } from '@tbd54566975/dwn-sdk-js';
-
-import Cursor from 'pg-cursor';
-import Database from 'better-sqlite3';
-import pg from 'pg';
-
-import { createPool as MySQLCreatePool } from 'mysql2';
+import type { Dialect } from '@tbd54566975/dwn-sql-store';
 import {
   DataStoreSql,
   EventLogSql,
@@ -25,6 +18,13 @@ import {
   PostgresDialect,
   SqliteDialect,
 } from '@tbd54566975/dwn-sql-store';
+
+import Database from 'better-sqlite3';
+import { createPool as MySQLCreatePool } from 'mysql2';
+import pg from 'pg';
+import Cursor from 'pg-cursor';
+
+import type { Config } from './config.js';
 
 export enum EStoreType {
   DataStore,

--- a/src/ws-api.ts
+++ b/src/ws-api.ts
@@ -1,17 +1,19 @@
+import { DataStream, type Dwn } from '@tbd54566975/dwn-sdk-js';
+
+import type { IncomingMessage, Server } from 'http';
 import { base64url } from 'multiformats/bases/base64';
 import { v4 as uuidv4 } from 'uuid';
-import { DataStream, type Dwn } from '@tbd54566975/dwn-sdk-js';
-import type { IncomingMessage, Server } from 'http';
 import { type AddressInfo, type WebSocket, WebSocketServer } from 'ws';
 
-import { jsonRpcApi } from './json-rpc-api.js';
 import type { RequestContext } from './lib/json-rpc-router.js';
-import { requestCounter } from './metrics.js';
 import {
   createJsonRpcErrorResponse,
   JsonRpcErrorCodes,
   type JsonRpcResponse,
 } from './lib/json-rpc.js';
+
+import { jsonRpcApi } from './json-rpc-api.js';
+import { requestCounter } from './metrics.js';
 
 const SOCKET_ISALIVE_SYMBOL = Symbol('isAlive');
 const HEARTBEAT_INTERVAL = 30_000;

--- a/tests/dwn-process-message.spec.ts
+++ b/tests/dwn-process-message.spec.ts
@@ -1,9 +1,9 @@
-import type { RequestContext } from '../src/lib/json-rpc-router.js';
-
-import { createJsonRpcRequest } from '../src/lib/json-rpc.js';
 import { expect } from 'chai';
-import { handleDwnProcessMessage } from '../src/json-rpc-handlers/dwn/process-message.js';
 import { v4 as uuidv4 } from 'uuid';
+
+import { handleDwnProcessMessage } from '../src/json-rpc-handlers/dwn/process-message.js';
+import type { RequestContext } from '../src/lib/json-rpc-router.js';
+import { createJsonRpcRequest } from '../src/lib/json-rpc.js';
 import { clear as clearDwn, dwn } from './test-dwn.js';
 import { createProfile, createRecordsWriteMessage } from './utils.js';
 

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -1,40 +1,39 @@
 // node.js 18 and earlier,  needs globalThis.crypto polyfill
-import { webcrypto } from 'node:crypto';
-
-if (!globalThis.crypto) {
-  // @ts-ignore
-  globalThis.crypto = webcrypto;
-}
-
-import type { Server } from 'http';
-import type {
-  JsonRpcErrorResponse,
-  JsonRpcResponse,
-} from '../src/lib/json-rpc.js';
-
-import fetch from 'node-fetch';
-import request from 'supertest';
-
-import { expect } from 'chai';
-import { HttpApi } from '../src/http-api.js';
-import { v4 as uuidv4 } from 'uuid';
 import {
   Cid,
   DataStream,
   RecordsQuery,
   RecordsRead,
 } from '@tbd54566975/dwn-sdk-js';
-import { clear as clearDwn, dwn } from './test-dwn.js';
+
+import { expect } from 'chai';
+import type { Server } from 'http';
+import fetch from 'node-fetch';
+import { webcrypto } from 'node:crypto';
+import request from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
+
+import { HttpApi } from '../src/http-api.js';
+import type {
+  JsonRpcErrorResponse,
+  JsonRpcResponse,
+} from '../src/lib/json-rpc.js';
 import {
   createJsonRpcRequest,
   JsonRpcErrorCodes,
 } from '../src/lib/json-rpc.js';
+import { clear as clearDwn, dwn } from './test-dwn.js';
 import {
   createProfile,
   createRecordsWriteMessage,
   getFileAsReadStream,
   streamHttpRequest,
 } from './utils.js';
+
+if (!globalThis.crypto) {
+  // @ts-ignore
+  globalThis.crypto = webcrypto;
+}
 
 describe('http api', function () {
   let httpApi: HttpApi;

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -182,7 +182,7 @@ export async function sendWsMessage(
     socket.onopen = (_event): void => {
       socket.onmessage = (event): void => {
         socket.terminate();
-        return resolve(<Buffer>event.data);
+        return resolve(event.data as Buffer);
       };
 
       socket.send(message);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,13 +1,4 @@
-import type { Readable } from 'readable-stream';
-import type { ReadStream } from 'node:fs';
 import type { PrivateJwk, PublicJwk, Signer } from '@tbd54566975/dwn-sdk-js';
-
-import fs from 'node:fs';
-import http from 'node:http';
-import path from 'path';
-
-import { fileURLToPath } from 'url';
-import { WebSocket } from 'ws';
 import {
   Cid,
   DataStream,
@@ -15,6 +6,14 @@ import {
   PrivateKeySigner,
   RecordsWrite,
 } from '@tbd54566975/dwn-sdk-js';
+
+import type { ReadStream } from 'node:fs';
+import fs from 'node:fs';
+import http from 'node:http';
+import path from 'path';
+import type { Readable } from 'readable-stream';
+import { fileURLToPath } from 'url';
+import { WebSocket } from 'ws';
 
 // __filename and __dirname are not defined in ES module scope
 const __filename = fileURLToPath(import.meta.url);

--- a/tests/ws-api.spec.ts
+++ b/tests/ws-api.spec.ts
@@ -1,17 +1,17 @@
-import http from 'node:http';
-
-import { base64url } from 'multiformats/bases/base64';
 import { DataStream } from '@tbd54566975/dwn-sdk-js';
+
 import { expect } from 'chai';
+import { base64url } from 'multiformats/bases/base64';
+import http from 'node:http';
 import { v4 as uuidv4 } from 'uuid';
 import { type WebSocketServer } from 'ws';
 
-import { WsApi } from '../src/ws-api.js';
-import { clear as clearDwn, dwn } from './test-dwn.js';
 import {
   createJsonRpcRequest,
   JsonRpcErrorCodes,
 } from '../src/lib/json-rpc.js';
+import { WsApi } from '../src/ws-api.js';
+import { clear as clearDwn, dwn } from './test-dwn.js';
 import {
   createProfile,
   createRecordsWriteMessage,


### PR DESCRIPTION
Closes: https://github.com/TBD54566975/dwn-server/issues/57

I tried to get a close approximation from the earlier eslint rule. Not an exact, but pretty close.

The earlier rule was already removed here: https://github.com/TBD54566975/dwn-server/commit/795d93b15bd6952ea318a5918660902c5f7addac

I tried to match the descriptions in eslint: https://eslint.org/docs/latest/rules/sort-imports#examples

The import orders are done a littler differently with the prettier plugin. So i tried to get an idea of how most of the imports are being done and then wrote the import order to approximate that.

Then i ran prettier on code base - so there is a commit that shows what the import sorting will look like