### PR TITLE
fix formatting in service.yaml

### DIFF
--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: { { include "dwn-server.fullname" . } }
-  labels: { { - include "dwn-server.labels" . | nindent 4 } }
+  name: {{ include "dwn-server.fullname" . }}
+  labels: {{ include "dwn-server.labels" . | nindent 4 }}
 spec:
-  type: { { .Values.service.type } }
+  type: {{ .Values.service.type }}
   ports:
-    - port: { { .Values.service.port } }
-      targetPort: { { .Values.service.targetPort } }
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
-  selector: { { - include "dwn-server.selectorLabels" . | nindent 4 } }
+  selector: {{ include "dwn-server.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
fix formatting in service.yaml. Was getting Release "dwn-server" does not exist. Installing it now. Error: YAML parse error on dwn-server/templates/service.yaml: error converting YAML to JSON: yaml: line 4: did not find expected node content