### PR TITLE
bump dwn sdk to v0.2.7

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -6,23 +6,27 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node: [18, 20]
+
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
-          node-version: 18
+          node-version: ${{ matrix.node }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run tests
         run: npm run test
 
       - name: Upload test coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -30,22 +34,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - run: docker build .
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - uses: DavidAnson/markdownlint-cli2-action@v13
+      - uses: DavidAnson/markdownlint-cli2-action@ed4dec634fd2ef689c7061d5647371d8248064f1 #v13.0.0
         with:
           globs: '**/*.md'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@web5/dwn-server",
       "version": "0.1.5",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.6",
+        "@tbd54566975/dwn-sdk-js": "0.2.7",
         "@tbd54566975/dwn-sql-store": "0.2.2",
         "better-sqlite3": "^8.5.0",
         "bytes": "3.1.2",
@@ -1161,9 +1161,9 @@
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.6.tgz",
-      "integrity": "sha512-q9HjMhW9KyUD94XVjuO4N+tkeZaOsgtRINIioMKucuZZTCb8Z2lilUleZqc7LiVePCMzlqdRBVeJpMKbnAGj8Q==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.7.tgz",
+      "integrity": "sha512-p7W7di+bf7X3mFu7HURYCr+WV4HJOu9SntqSjMf6J2i7PveOpwEfxQ16aEdTtPvg1v6i5GfMbYYmwuKDlRuBwA==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
@@ -1185,7 +1185,7 @@
         "ms": "2.1.3",
         "multiformats": "11.0.2",
         "randombytes": "2.1.0",
-        "readable-stream": "4.4.0",
+        "readable-stream": "4.4.2",
         "ulidx": "2.1.0",
         "uuid": "8.3.2",
         "varint": "6.0.0"
@@ -1195,14 +1195,15 @@
       }
     },
     "node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
-      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "process": "^0.11.10"
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1241,6 +1242,93 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.6.tgz",
+      "integrity": "sha512-q9HjMhW9KyUD94XVjuO4N+tkeZaOsgtRINIioMKucuZZTCb8Z2lilUleZqc7LiVePCMzlqdRBVeJpMKbnAGj8Q==",
+      "dependencies": {
+        "@ipld/dag-cbor": "9.0.3",
+        "@js-temporal/polyfill": "0.4.4",
+        "@noble/ed25519": "2.0.0",
+        "@noble/secp256k1": "2.0.0",
+        "abstract-level": "1.0.3",
+        "ajv": "8.12.0",
+        "blockstore-core": "4.2.0",
+        "cross-fetch": "4.0.0",
+        "eciesjs": "0.4.5",
+        "flat": "5.0.2",
+        "interface-blockstore": "5.2.3",
+        "interface-store": "5.1.2",
+        "ipfs-unixfs-exporter": "13.1.5",
+        "ipfs-unixfs-importer": "15.1.5",
+        "level": "8.0.0",
+        "lodash": "4.17.21",
+        "lru-cache": "9.1.2",
+        "ms": "2.1.3",
+        "multiformats": "11.0.2",
+        "randombytes": "2.1.0",
+        "readable-stream": "4.4.0",
+        "ulidx": "2.1.0",
+        "uuid": "8.3.2",
+        "varint": "6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.3.tgz",
+      "integrity": "sha512-A2UFccS0+sARK9xwXiVZIaWbLbPxLGP3UZOjBeOMWfDY04SXi8h1+t4rHBzOlKYF/yWNm3RbFLyclWO7hZcy4g==",
+      "dependencies": {
+        "cborg": "^2.0.1",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/cborg": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.5.tgz",
+      "integrity": "sha512-xVW1rSIw1ZXbkwl2XhJ7o/jAv0vnVoQv/QlfQxV8a7V5PlA4UU/AcIiXqmpyybwNWy/GPQU1m/aBVNIWr7/T0w==",
+      "bin": {
+        "cborg": "cli.js"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
+      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@tbd54566975/dwn-sql-store/node_modules/cborg": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.5.tgz",
@@ -1271,6 +1359,14 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.5",
       "dependencies": {
         "@tbd54566975/dwn-sdk-js": "0.2.7",
-        "@tbd54566975/dwn-sql-store": "0.2.2",
+        "@tbd54566975/dwn-sql-store": "0.2.3",
         "better-sqlite3": "^8.5.0",
         "bytes": "3.1.2",
         "cors": "2.8.5",
@@ -1218,15 +1218,18 @@
       }
     },
     "node_modules/@tbd54566975/dwn-sql-store": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.2.tgz",
-      "integrity": "sha512-hFyVliEha2Oq4sx76Jinc5cKxxC2ohgT1OA3Ih76BOFLaxP0TKT4xUV3XAUWFec24mvU/BepfK5ahCcE6qgK5g==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.3.tgz",
+      "integrity": "sha512-rxRIkMKe5yVLnimJecpLUgEs9Bwc7CbTJakrvF/iSXPcdVWoPmeDSCPjygomQ7vTp7e5AREUpN946t+TDi2puA==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.2.6",
+        "@tbd54566975/dwn-sdk-js": "0.2.7",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@tbd54566975/dwn-sql-store/node_modules/@ipld/dag-cbor": {
@@ -1240,93 +1243,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.6.tgz",
-      "integrity": "sha512-q9HjMhW9KyUD94XVjuO4N+tkeZaOsgtRINIioMKucuZZTCb8Z2lilUleZqc7LiVePCMzlqdRBVeJpMKbnAGj8Q==",
-      "dependencies": {
-        "@ipld/dag-cbor": "9.0.3",
-        "@js-temporal/polyfill": "0.4.4",
-        "@noble/ed25519": "2.0.0",
-        "@noble/secp256k1": "2.0.0",
-        "abstract-level": "1.0.3",
-        "ajv": "8.12.0",
-        "blockstore-core": "4.2.0",
-        "cross-fetch": "4.0.0",
-        "eciesjs": "0.4.5",
-        "flat": "5.0.2",
-        "interface-blockstore": "5.2.3",
-        "interface-store": "5.1.2",
-        "ipfs-unixfs-exporter": "13.1.5",
-        "ipfs-unixfs-importer": "15.1.5",
-        "level": "8.0.0",
-        "lodash": "4.17.21",
-        "lru-cache": "9.1.2",
-        "ms": "2.1.3",
-        "multiformats": "11.0.2",
-        "randombytes": "2.1.0",
-        "readable-stream": "4.4.0",
-        "ulidx": "2.1.0",
-        "uuid": "8.3.2",
-        "varint": "6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.3.tgz",
-      "integrity": "sha512-A2UFccS0+sARK9xwXiVZIaWbLbPxLGP3UZOjBeOMWfDY04SXi8h1+t4rHBzOlKYF/yWNm3RbFLyclWO7hZcy4g==",
-      "dependencies": {
-        "cborg": "^2.0.1",
-        "multiformats": "^12.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
-      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/cborg": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.5.tgz",
-      "integrity": "sha512-xVW1rSIw1ZXbkwl2XhJ7o/jAv0vnVoQv/QlfQxV8a7V5PlA4UU/AcIiXqmpyybwNWy/GPQU1m/aBVNIWr7/T0w==",
-      "bin": {
-        "cborg": "cli.js"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.0.tgz",
-      "integrity": "sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@tbd54566975/dwn-sql-store/node_modules/cborg": {
@@ -1359,14 +1275,6 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@web5/dwn-server",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@web5/dwn-server",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@tbd54566975/dwn-sdk-js": "0.2.7",
         "@tbd54566975/dwn-sql-store": "0.2.3",
@@ -22,7 +22,7 @@
         "pg": "^8.11.2",
         "pg-cursor": "^2.10.2",
         "prom-client": "14.2.0",
-        "readable-stream": "4.3.0",
+        "readable-stream": "4.4.2",
         "response-time": "2.3.2",
         "uuid": "9.0.0",
         "ws": "8.12.0"
@@ -34,7 +34,7 @@
         "@types/express": "4.17.17",
         "@types/mocha": "10.0.1",
         "@types/node": "18.11.18",
-        "@types/readable-stream": "2.3.15",
+        "@types/readable-stream": "4.0.6",
         "@types/supertest": "2.0.12",
         "@types/ws": "8.5.4",
         "@typescript-eslint/eslint-plugin": "5.59.0",
@@ -345,54 +345,6 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
-      "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
-      "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
-      "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.16.17",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
@@ -404,294 +356,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
-      "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
-      "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
-      "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
-      "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
-      "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
-      "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
-      "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
-      "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
-      "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
-      "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
-      "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
-      "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
-      "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
-      "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
-      "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
-      "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
-      "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
-      "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -1194,21 +858,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/@tbd54566975/dwn-sdk-js/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -1260,21 +909,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -1437,9 +1071,9 @@
       "dev": true
     },
     "node_modules/@types/readable-stream": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
-      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.6.tgz",
+      "integrity": "sha512-awa7+N1SSD9xz8ZvEUSO3/N3itc2PMH6Sca11HiX55TVsWiMaIgmbM76lN+2eZOrCQPiFqj0GmgsfsNtNGWoUw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -8393,14 +8027,15 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.3.0.tgz",
-      "integrity": "sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "process": "^0.11.10"
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@tbd54566975/dwn-sdk-js": "0.2.7",
-    "@tbd54566975/dwn-sql-store": "0.2.2",
+    "@tbd54566975/dwn-sql-store": "0.2.3",
     "better-sqlite3": "^8.5.0",
     "bytes": "3.1.2",
     "cors": "2.8.5",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/TBD54566975/dwn-server/issues"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.6",
+    "@tbd54566975/dwn-sdk-js": "0.2.7",
     "@tbd54566975/dwn-sql-store": "0.2.2",
     "better-sqlite3": "^8.5.0",
     "bytes": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@web5/dwn-server",
   "type": "module",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "files": [
     "dist",
     "src"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "pg": "^8.11.2",
     "pg-cursor": "^2.10.2",
     "prom-client": "14.2.0",
-    "readable-stream": "4.3.0",
+    "readable-stream": "4.4.2",
     "response-time": "2.3.2",
     "uuid": "9.0.0",
     "ws": "8.12.0"
@@ -49,7 +49,7 @@
     "@types/express": "4.17.17",
     "@types/mocha": "10.0.1",
     "@types/node": "18.11.18",
-    "@types/readable-stream": "2.3.15",
+    "@types/readable-stream": "4.0.6",
     "@types/supertest": "2.0.12",
     "@types/ws": "8.5.4",
     "@typescript-eslint/eslint-plugin": "5.59.0",


### PR DESCRIPTION
This PR will:
- Bump `@tbd54566975/dwn-sdk-js` from `v0.2.6` to `v0.2.7`.
- Bump `@tbd54566975/dwn-sql-store` from `v0.2.2` to `v0.2.3`.
- Bump `@types/readable-stream` from `v2.3.15` to `v.4.0.6` to match DWN SDK.
- Bump `readable-stream` from `v4.3.0` to `v4.4.2` to match DWN SDK.
- Add CI workflow testing for Node.js v18 since DWN SDK currently supports both v18 and v20.