### PR TITLE
bump dwn version and release new server version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@web5/dwn-server",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@web5/dwn-server",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.7",
-        "@tbd54566975/dwn-sql-store": "0.2.3",
+        "@tbd54566975/dwn-sdk-js": "0.2.8",
+        "@tbd54566975/dwn-sql-store": "0.2.4",
         "better-sqlite3": "^8.5.0",
         "bytes": "3.1.2",
         "cors": "2.8.5",
@@ -825,9 +825,9 @@
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.7.tgz",
-      "integrity": "sha512-p7W7di+bf7X3mFu7HURYCr+WV4HJOu9SntqSjMf6J2i7PveOpwEfxQ16aEdTtPvg1v6i5GfMbYYmwuKDlRuBwA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.8.tgz",
+      "integrity": "sha512-oiKk+ekAQO94bUkt6yk+xkDY8uCGmNC+rKaYQLhAoTrhYrczeRSuDT04F5/vPBT5K6NfAoRcQsIyBmvgRCUvgA==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
@@ -867,12 +867,12 @@
       }
     },
     "node_modules/@tbd54566975/dwn-sql-store": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.3.tgz",
-      "integrity": "sha512-rxRIkMKe5yVLnimJecpLUgEs9Bwc7CbTJakrvF/iSXPcdVWoPmeDSCPjygomQ7vTp7e5AREUpN946t+TDi2puA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.4.tgz",
+      "integrity": "sha512-LwSpQMcKtNEAj8ffn/UGrYwiENjN4S7rIDX5FDJ4+qjnMbF7I051i1bpw3INKnrtnVWAuynD5033EHSKLml0Zw==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.2.7",
+        "@tbd54566975/dwn-sdk-js": "0.2.8",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@web5/dwn-server",
   "type": "module",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "files": [
     "dist",
     "src"
@@ -23,8 +23,8 @@
     "url": "https://github.com/TBD54566975/dwn-server/issues"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.7",
-    "@tbd54566975/dwn-sql-store": "0.2.3",
+    "@tbd54566975/dwn-sdk-js": "0.2.8",
+    "@tbd54566975/dwn-sql-store": "0.2.4",
     "better-sqlite3": "^8.5.0",
     "bytes": "3.1.2",
     "cors": "2.8.5",


### PR DESCRIPTION
- bump `dwn-sdk-js` to v0.2.8
- bump `dwn-sql-store` to v0.2.4
- release `dwn-server` v0.1.7