### PR TITLE
introduce npx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,9 @@
         "uuid": "9.0.0",
         "ws": "8.12.0"
       },
+      "bin": {
+        "dwn-server": "dist/esm/src/main.js"
+      },
       "devDependencies": {
         "@trivago/prettier-plugin-sort-imports": "^4.2.0",
         "@types/bytes": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
       "require": "./dist/cjs/index.js"
     }
   },
+  "bin": {
+    "dwn-server": "./dist/esm/src/main.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/TBD54566975/dwn-server.git"

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // node.js 18 and earlier, needs globalThis.crypto polyfill. needed for dwn-sdk-js
 import { webcrypto } from 'node:crypto';
 


### PR DESCRIPTION
## Reason for PR

On some of our CI we run Docker which takes a whopping **7 minutes** on a macOS 12 runner. Setup of docker represents almost 50% of the entire time spent waiting on some CI runs. Yet many of our projects are already Javascript + npm environments that can run `node` binaries natively. We simply `npx @web5/dwn-server` and we're good to go. No Linux  hypervisor necessary. Option for Docker will still be there for cases where it's necessary.

## Implementation
Add support for `npx` with `bin` directive. See video for local run on my machine. Validated with `npx link` locally.

## Video
https://github.com/TBD54566975/dwn-server/assets/3495974/3a51d4b8-f792-466f-b9c8-75e451dee9f5

