### PR TITLE
Added support for synchronized proof-of-work challenge nonce across nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Configuration can be set using environment variables
 | `DS_MAX_RECORD_DATA_SIZE`                         | Maximum size for `RecordsWrite` data. use `b`, `kb`, `mb`, `gb` for value                                               | `1gb`                  |
 | `DS_WEBSOCKET_SERVER`                             | Whether to enable listening over `ws:`. values: `on`,`off`                                                              | `on`                   |
 | `DWN_REGISTRATION_STORE_URL`                      | URL to use for storage of registered DIDs. Leave unset to if DWN does not require registration (ie. open for all)       | unset                  |
+| `DWN_REGISTRATION_PROOF_OF_WORK_SEED`             | Seed to generate the challenge nonce from, this allows all DWN instances in a cluster to generate the same challenge.   | unset                  |
 | `DWN_REGISTRATION_PROOF_OF_WORK_ENABLED`          | Require new users to complete a proof-of-work challenge                                                                 | `false`                |
 | `DWN_REGISTRATION_PROOF_OF_WORK_INITIAL_MAX_HASH` | Initial maximum allowed hash in 64 char HEX string. The more leading zeros (smaller number) the higher the difficulty.  | `false`                |
 | `DWN_TERMS_OF_SERVICE_FILE_PATH`                  | Required terms of service agreement if set. Value is path to the terms of service file.                                 | unset                  |

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import bytes from 'bytes';
 
-export type Config = typeof config;
+export type DwnServerConfig = typeof config;
 
 export const config = {
   // max size of data that can be provided with a RecordsWrite
@@ -16,6 +16,7 @@ export const config = {
 
   // tenant registration feature configuration
   registrationStoreUrl: process.env.DWN_REGISTRATION_STORE_URL || process.env.DWN_STORAGE,
+  registrationProofOfWorkSeed: process.env.DWN_REGISTRATION_PROOF_OF_WORK_SEED,
   registrationProofOfWorkEnabled: process.env.DWN_REGISTRATION_PROOF_OF_WORK_ENABLED === 'true',
   registrationProofOfWorkInitialMaxHash: process.env.DWN_REGISTRATION_PROOF_OF_WORK_INITIAL_MAX_HASH,
   termsOfServiceFilePath: process.env.DWN_TERMS_OF_SERVICE_FILE_PATH,

--- a/src/dwn-server.ts
+++ b/src/dwn-server.ts
@@ -7,7 +7,7 @@ import { type WebSocketServer } from 'ws';
 
 import { HttpServerShutdownHandler } from './lib/http-server-shutdown-handler.js';
 
-import { type Config, config as defaultConfig } from './config.js';
+import { type DwnServerConfig, config as defaultConfig } from './config.js';
 import { HttpApi } from './http-api.js';
 import { setProcessHandlers } from './process-handlers.js';
 import { getDWNConfig } from './storage.js';
@@ -16,12 +16,12 @@ import { RegistrationManager } from './registration/registration-manager.js';
 
 export type DwnServerOptions = {
   dwn?: Dwn;
-  config?: Config;
+  config?: DwnServerConfig;
 };
 
 export class DwnServer {
   dwn?: Dwn;
-  config: Config;
+  config: DwnServerConfig;
   #httpServerShutdownHandler: HttpServerShutdownHandler;
   #httpApi: HttpApi;
   #wsApi: WsApi;
@@ -57,7 +57,8 @@ export class DwnServer {
       registrationManager = await RegistrationManager.create({
         registrationStoreUrl: this.config.registrationStoreUrl,
         termsOfServiceFilePath: this.config.termsOfServiceFilePath,
-        initialMaximumAllowedHashValue: this.config.registrationProofOfWorkInitialMaxHash,
+        proofOfWorkChallengeNonceSeed: this.config.registrationProofOfWorkSeed,
+        proofOfWorkInitialMaximumAllowedHash: this.config.registrationProofOfWorkInitialMaxHash,
       });
 
       this.dwn = await Dwn.create(getDWNConfig(this.config, registrationManager));

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -14,7 +14,7 @@ import type { RequestContext } from './lib/json-rpc-router.js';
 import type { JsonRpcRequest } from './lib/json-rpc.js';
 import { createJsonRpcErrorResponse, JsonRpcErrorCodes } from './lib/json-rpc.js';
 
-import type { Config } from './config.js';
+import type { DwnServerConfig } from './config.js';
 import { config } from './config.js';
 import { type DwnServerError } from './dwn-error.js';
 import { jsonRpcApi } from './json-rpc-api.js';
@@ -24,13 +24,13 @@ import type { RegistrationManager } from './registration/registration-manager.js
 const packageJson = process.env.npm_package_json ? JSON.parse(readFileSync(process.env.npm_package_json).toString()) : {};
 
 export class HttpApi {
-  #config: Config;
+  #config: DwnServerConfig;
   #api: Express;
   #server: http.Server;
   registrationManager: RegistrationManager;
   dwn: Dwn;
 
-  constructor(config: Config, dwn: Dwn, registrationManager: RegistrationManager) {
+  constructor(config: DwnServerConfig, dwn: Dwn, registrationManager: RegistrationManager) {
     console.log(config);
 
     this.#config = config;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Config } from './config.js';
+export { DwnServerConfig } from './config.js';
 export { DwnServer, DwnServerOptions } from './dwn-server.js';
 export { HttpApi } from './http-api.js';
 export { jsonRpcApi } from './json-rpc-api.js';

--- a/src/lib/http-server-shutdown-handler.ts
+++ b/src/lib/http-server-shutdown-handler.ts
@@ -58,8 +58,8 @@ export class HttpServerShutdownHandler {
 
     // Stops the server from accepting new connections and keeps existing connections. This function is asynchronous,
     // the server is finally closed when all connections are ended and the server emits a 'close' event.
-    // The optional callback will be called once the 'close' event occurs. Unlike that event, it will be
-    // called with an Error as its only argument if the server was not open when it was closed.
+    // The optional callback will be called once the 'close' event occurs.
+    // The callback will be called with an Error as its only argument if the server was not open when close is called.
     this.server.close(() => {
       this.tcpSocketId = 0;
       this.stopping = false;

--- a/src/registration/registration-manager.ts
+++ b/src/registration/registration-manager.ts
@@ -50,9 +50,10 @@ export class RegistrationManager implements TenantGate {
   public static async create(input: {
     registrationStoreUrl?: string,
     termsOfServiceFilePath?: string
-    initialMaximumAllowedHashValue?: string,
+    proofOfWorkChallengeNonceSeed?: string,
+    proofOfWorkInitialMaximumAllowedHash?: string,
   }): Promise<RegistrationManager> {
-    const { termsOfServiceFilePath, registrationStoreUrl, initialMaximumAllowedHashValue } = input;
+    const { termsOfServiceFilePath, registrationStoreUrl } = input;
 
     const registrationManager = new RegistrationManager();
 
@@ -71,7 +72,8 @@ export class RegistrationManager implements TenantGate {
     registrationManager.proofOfWorkManager = await ProofOfWorkManager.create({
       autoStart: true,
       desiredSolveCountPerMinute: 10,
-      initialMaximumAllowedHashValue,
+      initialMaximumAllowedHashValue: input.proofOfWorkInitialMaximumAllowedHash,
+      challengeSeed: input.proofOfWorkChallengeNonceSeed,
     });
 
     // Initialize RegistrationStore.

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -27,7 +27,7 @@ import { createPool as MySQLCreatePool } from 'mysql2';
 import pg from 'pg';
 import Cursor from 'pg-cursor';
 
-import type { Config } from './config.js';
+import type { DwnServerConfig } from './config.js';
 
 export enum EStoreType {
   DataStore,
@@ -45,7 +45,7 @@ export enum BackendTypes {
 export type StoreType = DataStore | EventLog | MessageStore;
 
 export function getDWNConfig(
-  config: Config,
+  config: DwnServerConfig,
   tenantGate: TenantGate,
 ): DwnConfig {
   const dataStore: DataStore = getStore(config.dataStore, EStoreType.DataStore);

--- a/tests/dwn-server.spec.ts
+++ b/tests/dwn-server.spec.ts
@@ -1,33 +1,45 @@
 import { expect } from 'chai';
 
+import type { DwnServerConfig } from '../src/config.js';
 import { config } from '../src/config.js';
 import { DwnServer } from '../src/dwn-server.js';
+import { randomBytes } from 'crypto';
 
 describe('DwnServer', function () {
-  let dwnServer: DwnServer;
+  const dwnServerConfig = { ...config };
+  
   before(async function () {
-    dwnServer = new DwnServer({ config });
+    // NOTE: using SQL to workaround an issue where multiple instances of DwnServer can be started using LevelDB in the same test run,
+    // and dwn-server.spec.ts already uses LevelDB.
+    dwnServerConfig.messageStore = 'sqlite://';
+    dwnServerConfig.dataStore = 'sqlite://';
+    dwnServerConfig.eventLog = 'sqlite://';
   });
 
   after(async function () {
-    dwnServer.stop(() => console.log('server stop'));
   });
 
-  it('should create an instance of DwnServer', function () {
-    expect(dwnServer).to.be.an.instanceOf(DwnServer);
-  });
+  it('should initialize ProofOfWorkManager with challenge nonce seed if given.', async function () {
+    const registrationProofOfWorkSeed = randomBytes(32).toString('hex');
+    const configWithProofOfWorkSeed: DwnServerConfig = {
+      ...dwnServerConfig,
+      registrationStoreUrl: 'sqlite://',
+      registrationProofOfWorkEnabled: true,
+      registrationProofOfWorkSeed
+    };
 
-  it('should start the server and listen on the specified port', async function () {
+    const dwnServer = new DwnServer({ config: configWithProofOfWorkSeed });
     await dwnServer.start();
-    const response = await fetch('http://localhost:3000', {
-      method: 'GET',
-    });
-    expect(response.status).to.equal(200);
+    expect(dwnServer.registrationManager['proofOfWorkManager']['challengeSeed']).to.equal(registrationProofOfWorkSeed);
+
+    dwnServer.stop(() => console.log('server Stop'));
   });
 
-  it('should stop the server', async function () {
-    dwnServer.stop(() => console.log('server Stop'));
-    // Add an assertion to check that the server has been stopped
-    expect(dwnServer.httpServer.listening).to.be.false;
-  });
+  // it('should stop listening to HTTP requests when stopped.', async function () {
+  //   const dwnServer = new DwnServer({ config: dwnServerConfig });
+  //   await dwnServer.start();
+  //   dwnServer.stop(() => console.log('server Stop'));
+  //   // Add an assertion to check that the server has been stopped
+  //   expect(dwnServer.httpServer.listening).to.be.false;
+  // });
 });

--- a/tests/dwn-server.spec.ts
+++ b/tests/dwn-server.spec.ts
@@ -33,13 +33,6 @@ describe('DwnServer', function () {
     expect(dwnServer.registrationManager['proofOfWorkManager']['challengeSeed']).to.equal(registrationProofOfWorkSeed);
 
     dwnServer.stop(() => console.log('server Stop'));
+    expect(dwnServer.httpServer.listening).to.be.false;
   });
-
-  // it('should stop listening to HTTP requests when stopped.', async function () {
-  //   const dwnServer = new DwnServer({ config: dwnServerConfig });
-  //   await dwnServer.start();
-  //   dwnServer.stop(() => console.log('server Stop'));
-  //   // Add an assertion to check that the server has been stopped
-  //   expect(dwnServer.httpServer.listening).to.be.false;
-  // });
 });

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -59,8 +59,8 @@ describe('http api', function () {
     // RegistrationManager creation
     const registrationStoreUrl = config.registrationStoreUrl;
     const termsOfServiceFilePath = config.termsOfServiceFilePath;
-    const initialMaximumAllowedHashValue = config.registrationProofOfWorkInitialMaxHash;
-    registrationManager = await RegistrationManager.create({ registrationStoreUrl, termsOfServiceFilePath, initialMaximumAllowedHashValue });
+    const proofOfWorkInitialMaximumAllowedHash = config.registrationProofOfWorkInitialMaxHash;
+    registrationManager = await RegistrationManager.create({ registrationStoreUrl, termsOfServiceFilePath, proofOfWorkInitialMaximumAllowedHash });
 
     dwn = await getTestDwn(registrationManager);
 


### PR DESCRIPTION
Added support for synchronized proof-of-work challenge nonce across nodes by:
- Added a seed for proof-of-work to allow deterministic challenge nonce generation.
- Allowed for slight server clock drift.

With this PR, the registration endpoint with proof-of-work is now ready to be used in a production environment with many nodes.