### PR TITLE
Bump `dwn-sdk-js` to `0.2.14`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@web5/dwn-server",
       "version": "0.1.9",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.12",
-        "@tbd54566975/dwn-sql-store": "0.2.6",
+        "@tbd54566975/dwn-sdk-js": "0.2.14",
+        "@tbd54566975/dwn-sql-store": "0.2.8",
         "better-sqlite3": "^8.5.0",
         "body-parser": "^1.20.2",
         "bytes": "3.1.2",
@@ -130,6 +130,65 @@
       "dev": true,
       "engines": {
         "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@decentralized-identity/ion-pow-sdk": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@decentralized-identity/ion-pow-sdk/-/ion-pow-sdk-1.0.17.tgz",
+      "integrity": "sha512-vk7DTDM8aKDbFyu1ad/qkoRrGL4q+KvNeL/FNZXhkWPaDhVExBN/qGEoRLf1YSfFe+myto3+4RYTPut+riiqnw==",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "cross-fetch": "3.1.5",
+        "hash-wasm": "4.9.0"
+      }
+    },
+    "node_modules/@decentralized-identity/ion-pow-sdk/node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/@decentralized-identity/ion-pow-sdk/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@decentralized-identity/ion-sdk": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@decentralized-identity/ion-sdk/-/ion-sdk-1.0.1.tgz",
+      "integrity": "sha512-+P+DXcRSFjsEsI5KIqUmVjpzgUT28B2lWpTO+IxiBcfibAN/1Sg20NebGTO/+serz2CnSZf95N2a1OZ6eXypGQ==",
+      "dependencies": {
+        "@noble/ed25519": "^2.0.0",
+        "@noble/secp256k1": "^2.0.0",
+        "canonicalize": "^2.0.0",
+        "multiformats": "^12.0.1",
+        "multihashes": "^4.0.3",
+        "uri-js": "^4.4.1"
+      }
+    },
+    "node_modules/@decentralized-identity/ion-sdk/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
@@ -366,6 +425,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+    },
+    "node_modules/@multiformats/base-x": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+    },
     "node_modules/@multiformats/murmur3": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.7.tgz",
@@ -569,14 +638,15 @@
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.12.tgz",
-      "integrity": "sha512-Y1ENGZcaHyqc+NG+EXFAN7k/zRqJ5JuBr9cbkpupqUuhwN9Xjdej8uuoGviHx/72jhpx9dKfcCBeHztiTMMZOg==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.14.tgz",
+      "integrity": "sha512-RMaxsjcHomS8lm75LQzhaVA+gKxcZsf0cKANIbuR7qfGGDVyBzM1WcwN5TwuRTKMHCcDmOPwKj6IxaHqoKrI4g==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
         "@noble/ed25519": "2.0.0",
         "@noble/secp256k1": "2.0.0",
+        "@web5/dids": "^0.2.4",
         "abstract-level": "1.0.3",
         "ajv": "8.12.0",
         "blockstore-core": "4.2.0",
@@ -610,12 +680,12 @@
       }
     },
     "node_modules/@tbd54566975/dwn-sql-store": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.6.tgz",
-      "integrity": "sha512-N5SSyKGgHoW7ttWW6xrPq4xK7aYfxDvrmXdYEi+eA3qlT+Wzi5HZfrlcSnFIHee9+s56V6WpJw1AQ6XmjZH2QQ==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.8.tgz",
+      "integrity": "sha512-sUDH8AXPOJ757+JXCdP16SYL1ZglpQiiSvqxPa0gIYbe5blcNNzAvuY9pz0ISJX8wW4l6JouxxZFDUdRfXPRKw==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.2.10",
+        "@tbd54566975/dwn-sdk-js": "0.2.14",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"
@@ -637,78 +707,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.10.tgz",
-      "integrity": "sha512-CoKO8+NciwWNzD4xRoAAgeElqQCXKM4Fc+zEHsUWD0M3E9v67hRWiTHI6AenUfQv1RSEB2H4GHUeUOHuEV72uw==",
-      "dependencies": {
-        "@ipld/dag-cbor": "9.0.3",
-        "@js-temporal/polyfill": "0.4.4",
-        "@noble/ed25519": "2.0.0",
-        "@noble/secp256k1": "2.0.0",
-        "abstract-level": "1.0.3",
-        "ajv": "8.12.0",
-        "blockstore-core": "4.2.0",
-        "cross-fetch": "4.0.0",
-        "eciesjs": "0.4.5",
-        "interface-blockstore": "5.2.3",
-        "interface-store": "5.1.2",
-        "ipfs-unixfs-exporter": "13.1.5",
-        "ipfs-unixfs-importer": "15.1.5",
-        "level": "8.0.0",
-        "lodash": "4.17.21",
-        "lru-cache": "9.1.2",
-        "ms": "2.1.3",
-        "multiformats": "11.0.2",
-        "randombytes": "2.1.0",
-        "readable-stream": "4.4.2",
-        "ulidx": "2.1.0",
-        "uuid": "8.3.2",
-        "varint": "6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.3.tgz",
-      "integrity": "sha512-A2UFccS0+sARK9xwXiVZIaWbLbPxLGP3UZOjBeOMWfDY04SXi8h1+t4rHBzOlKYF/yWNm3RbFLyclWO7hZcy4g==",
-      "dependencies": {
-        "cborg": "^2.0.1",
-        "multiformats": "^12.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
-      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/cborg": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.5.tgz",
-      "integrity": "sha512-xVW1rSIw1ZXbkwl2XhJ7o/jAv0vnVoQv/QlfQxV8a7V5PlA4UU/AcIiXqmpyybwNWy/GPQU1m/aBVNIWr7/T0w==",
-      "bin": {
-        "cborg": "cli.js"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
     "node_modules/@tbd54566975/dwn-sql-store/node_modules/cborg": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.5.tgz",
@@ -724,14 +722,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -1133,6 +1123,95 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@web5/common": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.2.tgz",
+      "integrity": "sha512-dRn6SmALExeTLMTK/W5ozGarfaddK+Lraf5OjuIGLAaLfcX1RWx3oDMoY5Hr9LjfxHJC8mGXB8DnKflbeYJRgA==",
+      "dependencies": {
+        "level": "8.0.0",
+        "multiformats": "11.0.2",
+        "readable-stream": "4.4.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web5/crypto": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.2.2.tgz",
+      "integrity": "sha512-vHFg0wXQSQXrwuBNQyDHnmSZchfTfO6/Sv+7rDsNkvofs+6lGTE8CZ02cwUYMeIwTRMLer12c+fMfzYrXokEUQ==",
+      "dependencies": {
+        "@noble/ciphers": "0.1.4",
+        "@noble/curves": "1.1.0",
+        "@noble/hashes": "1.3.1",
+        "@web5/common": "0.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web5/crypto/node_modules/@noble/ciphers": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.1.4.tgz",
+      "integrity": "sha512-d3ZR8vGSpy3v/nllS+bD/OMN5UZqusWiQqkyj7AwzTnhXFH72pF5oB4Ach6DQ50g5kXxC28LdaYBEpsyv9KOUQ==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web5/crypto/node_modules/@noble/curves": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+      "dependencies": {
+        "@noble/hashes": "1.3.1"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web5/crypto/node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@web5/crypto/node_modules/@web5/common": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.1.tgz",
+      "integrity": "sha512-Tt5P17HgQCx+Epw0IHnhRKqp5UU3E4xtsE8PkdghOBnvntBB0op5P6efvR1WqmJft5+VunDHt3yZAZstuqQkNg==",
+      "dependencies": {
+        "level": "8.0.0",
+        "multiformats": "11.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web5/dids": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.2.4.tgz",
+      "integrity": "sha512-e+m+xgpiM8ydTJgWcPdwmjILLMZYdl2kwahlO22mK0azSKVrg1klpGrUODzqkrWrQ5O0tnOyqEy39FcD5Sy11w==",
+      "dependencies": {
+        "@decentralized-identity/ion-pow-sdk": "1.0.17",
+        "@decentralized-identity/ion-sdk": "1.0.1",
+        "@web5/common": "0.2.2",
+        "@web5/crypto": "0.2.2",
+        "did-resolver": "4.1.0",
+        "dns-packet": "5.6.1",
+        "level": "8.0.0",
+        "ms": "2.1.3",
+        "pkarr": "1.1.1",
+        "z32": "1.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1436,14 +1515,21 @@
     "node_modules/b4a": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.4.tgz",
-      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==",
-      "dev": true
+      "integrity": "sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1482,6 +1568,17 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bencode": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-3.1.1.tgz",
+      "integrity": "sha512-btsxX9201yoWh45TdqYg6+OZ5O1xTYKTYSGvJndICDFtznE/9zXgow8yjMvvhOqKKuzuL7h+iiCMpfkG8+QuBA==",
+      "dependencies": {
+        "uint8-util": "^2.1.6"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/better-sqlite3": {
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.7.0.tgz",
@@ -1514,6 +1611,49 @@
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
+    "node_modules/bittorrent-dht": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/bittorrent-dht/-/bittorrent-dht-11.0.5.tgz",
+      "integrity": "sha512-R09D6uNaziRqsc+B/j5QzkjceTak+wH9vcNLnkmt8A52EWF9lQwBP0vvCKgSA3AJOYYl+41n3osA2KYYn/z5uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "bencode": "^4.0.0",
+        "debug": "^4.3.4",
+        "k-bucket": "^5.1.0",
+        "k-rpc": "^5.1.0",
+        "last-one-wins": "^1.0.4",
+        "lru": "^3.1.0",
+        "randombytes": "^2.1.0",
+        "record-cache": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/bittorrent-dht/node_modules/bencode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-4.0.0.tgz",
+      "integrity": "sha512-AERXw18df0pF3ziGOCyUjqKZBVNH8HV3lBxnx5w0qtgMIk4a1wb9BkcCQbkp9Zstfrn/dzRwl7MmUHHocX3sRQ==",
+      "dependencies": {
+        "uint8-util": "^2.2.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/bl": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
@@ -1535,6 +1675,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/blake2b": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
+      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
+      "dependencies": {
+        "blake2b-wasm": "^2.4.0",
+        "nanoassert": "^2.0.0"
+      }
+    },
+    "node_modules/blake2b-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
+      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "nanoassert": "^2.0.0"
       }
     },
     "node_modules/blockstore-core": {
@@ -1854,6 +2012,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/canonicalize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.0.0.tgz",
+      "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w=="
+    },
     "node_modules/catering": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
@@ -1868,6 +2031,14 @@
       "integrity": "sha512-xVW1rSIw1ZXbkwl2XhJ7o/jAv0vnVoQv/QlfQxV8a7V5PlA4UU/AcIiXqmpyybwNWy/GPQU1m/aBVNIWr7/T0w==",
       "bin": {
         "cborg": "cli.js"
+      }
+    },
+    "node_modules/chacha20-universal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chacha20-universal/-/chacha20-universal-1.0.4.tgz",
+      "integrity": "sha512-/IOxdWWNa7nRabfe7+oF+jVkGjlr2xUL4J8l/OvzZhj+c9RpMqoo3Dq+5nU1j/BflRV4BKnaQ4+4oH1yBpQG1Q==",
+      "dependencies": {
+        "nanoassert": "^2.0.0"
       }
     },
     "node_modules/chai": {
@@ -1969,6 +2140,59 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/chrome-dgram": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/chrome-dgram/-/chrome-dgram-3.0.6.tgz",
+      "integrity": "sha512-bqBsUuaOiXiqxXt/zA/jukNJJ4oaOtc7ciwqJpZVEaaXwwxqgI2/ZdG02vXYWUhHGziDlvGMQWk0qObgJwVYKA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "run-series": "^1.1.9"
+      }
+    },
+    "node_modules/chrome-dns": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chrome-dns/-/chrome-dns-1.0.1.tgz",
+      "integrity": "sha512-HqsYJgIc8ljJJOqOzLphjAs79EUuWSX3nzZi2LNkzlw3GIzAeZbaSektC8iT/tKvLqZq8yl1GJu5o6doA4TRbg==",
+      "dependencies": {
+        "chrome-net": "^3.3.2"
+      }
+    },
+    "node_modules/chrome-net": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/chrome-net/-/chrome-net-3.3.4.tgz",
+      "integrity": "sha512-Jzy2EnzmE+ligqIZUsmWnck9RBXLuUy6CaKyuNMtowFG3ZvLt8d+WBJCTPEludV0DHpIKjAOlwjFmTaEdfdWCw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "inherits": "^2.0.1"
+      }
     },
     "node_modules/chromium-bidi": {
       "version": "0.4.33",
@@ -2677,6 +2901,11 @@
       "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
       "dev": true
     },
+    "node_modules/did-resolver": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/did-resolver/-/did-resolver-4.1.0.tgz",
+      "integrity": "sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA=="
+    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -2713,6 +2942,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/doctrine": {
@@ -4337,6 +4577,14 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/graceful-goodbye": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/graceful-goodbye/-/graceful-goodbye-1.3.0.tgz",
+      "integrity": "sha512-hcZOs20emYlTM7MmUE0FpuZcjlk2GPsR+UYTHDeWxtGjXcbh2CawGi8vlzqsIvspqAbot7mRv3sC/uhgtKc4hQ==",
+      "dependencies": {
+        "safety-catch": "^1.0.2"
+      }
+    },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
@@ -4478,6 +4726,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/hash-wasm": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.9.0.tgz",
+      "integrity": "sha512-7SW7ejyfnRxuOc7ptQHSf4LDoZaWOivfzqw+5rpcQku0nHfmicPKE51ra9BiRLAmT8+gGLestr1XroUkqdjL6w=="
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -5403,6 +5656,40 @@
       "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
       "dev": true
     },
+    "node_modules/k-bucket": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-5.1.0.tgz",
+      "integrity": "sha512-Fac7iINEovXIWU20GPnOMLUbjctiS+cnmyjC4zAUgvs3XPf1vo9akfCHkigftSic/jiKqKl+KA3a/vFcJbHyCg==",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/k-rpc": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/k-rpc/-/k-rpc-5.1.0.tgz",
+      "integrity": "sha512-FGc+n70Hcjoa/X2JTwP+jMIOpBz+pkRffHnSl9yrYiwUxg3FIgD50+u1ePfJUOnRCnx6pbjmVk5aAeB1wIijuQ==",
+      "dependencies": {
+        "k-bucket": "^5.0.0",
+        "k-rpc-socket": "^1.7.2",
+        "randombytes": "^2.0.5"
+      }
+    },
+    "node_modules/k-rpc-socket": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/k-rpc-socket/-/k-rpc-socket-1.11.1.tgz",
+      "integrity": "sha512-8xtA8oqbZ6v1Niryp2/g4GxW16EQh5MvrUylQoOG+zcrDff5CKttON2XUXvMwlIHq4/2zfPVFiinAccJ+WhxoA==",
+      "dependencies": {
+        "bencode": "^2.0.0",
+        "chrome-dgram": "^3.0.2",
+        "chrome-dns": "^1.0.0",
+        "chrome-net": "^3.3.2"
+      }
+    },
+    "node_modules/k-rpc-socket/node_modules/bencode": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bencode/-/bencode-2.0.3.tgz",
+      "integrity": "sha512-D/vrAD4dLVX23NalHwb8dSvsUsxeRPO8Y7ToKA015JQYq69MLDOMkC0uGZYA/MPpltLO8rt8eqFC2j8DxjTZ/w=="
+    },
     "node_modules/karma": {
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.2.tgz",
@@ -5635,6 +5922,11 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/last-one-wins": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/last-one-wins/-/last-one-wins-1.0.4.tgz",
+      "integrity": "sha512-t+KLJFkHPQk8lfN6WBOiGkiUXoub+gnb2XTYI2P3aiISL+94xgZ1vgz1SXN/N4hthuOoLXarXfBZPUruyjQtfA=="
     },
     "node_modules/layerr": {
       "version": "2.0.1",
@@ -5984,6 +6276,17 @@
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lru": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz",
+      "integrity": "sha512-5OUtoiVIGU4VXBOshidmtOsvBIvcQR6FD/RzWSvaeHyxCGB+PCUCu+52lqMfdc0h/2CLvHhZS4TwUmMQrrMbBQ==",
+      "dependencies": {
+        "inherits": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/lru-cache": {
@@ -6456,6 +6759,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/multibase": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
+      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
+      "deprecated": "This module has been superseded by the multiformats module",
+      "dependencies": {
+        "@multiformats/base-x": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
     "node_modules/multiformats": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
@@ -6464,6 +6780,38 @@
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/multihashes": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
+      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
+      "dependencies": {
+        "multibase": "^4.0.1",
+        "uint8arrays": "^3.0.0",
+        "varint": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/multihashes/node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+    },
+    "node_modules/multihashes/node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/multihashes/node_modules/varint": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -6528,6 +6876,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -7182,6 +7535,34 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/pkarr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkarr/-/pkarr-1.1.1.tgz",
+      "integrity": "sha512-X27LKqf83X3WuJd2Z9qdfVxkmfOu6HUbY0pm11LqeBbFmgmZRPgOxJG8bKiIsmmD6Vjc25j45KHYflF2lfodyQ==",
+      "dependencies": {
+        "bencode": "^3.0.3",
+        "bittorrent-dht": "^11.0.4",
+        "chalk": "^5.2.0",
+        "dns-packet": "^5.6.1",
+        "graceful-goodbye": "^1.3.0",
+        "sodium-universal": "^4.0.0",
+        "z32": "^1.0.0"
+      },
+      "bin": {
+        "pkarr": "bin.js"
+      }
+    },
+    "node_modules/pkarr/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
@@ -7624,6 +8005,14 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/record-cache": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/record-cache/-/record-cache-1.2.0.tgz",
+      "integrity": "sha512-kyy3HWCez2WrotaL3O4fTn0rsIdfRKOdQQcEJ9KpvmKmbffKVvwsloX063EgRUlpJIXHiDQFhJcTbZequ2uTZw==",
+      "dependencies": {
+        "b4a": "^1.3.1"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
@@ -7848,6 +8237,25 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/run-series": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
+      "integrity": "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-array-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
@@ -7889,6 +8297,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/safety-catch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/safety-catch/-/safety-catch-1.0.2.tgz",
+      "integrity": "sha512-C1UYVZ4dtbBxEtvOcpjBaaD27nP8MlvyAQEp2fOTOEe6pfUpk1cDUxij6BR1jZup6rSyUTaBBplK7LanskrULA=="
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -8036,6 +8449,42 @@
         "sha.js": "bin.js"
       }
     },
+    "node_modules/sha256-universal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sha256-universal/-/sha256-universal-1.2.1.tgz",
+      "integrity": "sha512-ghn3muhdn1ailCQqqceNxRgkOeZSVfSE13RQWEg6njB+itsFzGVSJv+O//2hvNXZuxVIRyNzrgsZ37SPDdGJJw==",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "sha256-wasm": "^2.2.1"
+      }
+    },
+    "node_modules/sha256-wasm": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/sha256-wasm/-/sha256-wasm-2.2.2.tgz",
+      "integrity": "sha512-qKSGARvao+JQlFiA+sjJZhJ/61gmW/3aNLblB2rsgIxDlDxsJPHo8a1seXj12oKtuHVgJSJJ7QEGBUYQN741lQ==",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "nanoassert": "^2.0.0"
+      }
+    },
+    "node_modules/sha512-universal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sha512-universal/-/sha512-universal-1.2.1.tgz",
+      "integrity": "sha512-kehYuigMoRkIngCv7rhgruLJNNHDnitGTBdkcYbCbooL8Cidj/bS78MDxByIjcc69M915WxcQTgZetZ1JbeQTQ==",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "sha512-wasm": "^2.3.1"
+      }
+    },
+    "node_modules/sha512-wasm": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/sha512-wasm/-/sha512-wasm-2.3.4.tgz",
+      "integrity": "sha512-akWoxJPGCB3aZCrZ+fm6VIFhJ/p8idBv7AWGFng/CZIrQo51oQNsvDbTSRXWAzIiZJvpy16oIDiCCPqTe21sKg==",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "nanoassert": "^2.0.0"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -8166,6 +8615,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/siphash24": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.3.1.tgz",
+      "integrity": "sha512-moemC3ZKiTzH29nbFo3Iw8fbemWWod4vNs/WgKbQ54oEs6mE6XVlguxvinYjB+UmaE0PThgyED9fUkWvirT8hA==",
+      "dependencies": {
+        "nanoassert": "^2.0.0"
       }
     },
     "node_modules/slash": {
@@ -8309,6 +8766,45 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
       "dev": true
+    },
+    "node_modules/sodium-javascript": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/sodium-javascript/-/sodium-javascript-0.8.0.tgz",
+      "integrity": "sha512-rEBzR5mPxPES+UjyMDvKPIXy9ImF17KOJ32nJNi9uIquWpS/nfj+h6m05J5yLJaGXjgM72LmQoUbWZVxh/rmGg==",
+      "dependencies": {
+        "blake2b": "^2.1.1",
+        "chacha20-universal": "^1.0.4",
+        "nanoassert": "^2.0.0",
+        "sha256-universal": "^1.1.0",
+        "sha512-universal": "^1.1.0",
+        "siphash24": "^1.0.1",
+        "xsalsa20": "^1.0.0"
+      }
+    },
+    "node_modules/sodium-native": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.0.6.tgz",
+      "integrity": "sha512-uYsyycwcz9kYDwpXxJmL2YZosynsxcP6RPySbARVJdC9uNDa2CMjzJ7/WsMMvThKgvAYsBWdZc7L/WSVj9lTcA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-gyp-build": "^4.6.0"
+      }
+    },
+    "node_modules/sodium-universal": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sodium-universal/-/sodium-universal-4.0.0.tgz",
+      "integrity": "sha512-iKHl8XnBV96k1c75gwwzANFdephw/MDWSjQAjPmBE+du0y3P23Q8uf7AcdcfFsYAMwLg7WVBfSAIBtV/JvRsjA==",
+      "dependencies": {
+        "blake2b": "^2.1.1",
+        "chacha20-universal": "^1.0.4",
+        "nanoassert": "^2.0.0",
+        "sha256-universal": "^1.1.0",
+        "sha512-universal": "^1.1.0",
+        "siphash24": "^1.0.1",
+        "sodium-javascript": "~0.8.0",
+        "sodium-native": "^4.0.0",
+        "xsalsa20": "^1.0.0"
+      }
     },
     "node_modules/sparse-array": {
       "version": "1.3.2",
@@ -8953,6 +9449,14 @@
         "node": "*"
       }
     },
+    "node_modules/uint8-util": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/uint8-util/-/uint8-util-2.2.4.tgz",
+      "integrity": "sha512-uEI5lLozmKQPYEevfEhP9LY3Je5ZmrQhaWXrzTVqrLNQl36xsRh8NiAxYwB9J+2BAt99TRbmCkROQB2ZKhx4UA==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
     "node_modules/uint8arraylist": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.3.tgz",
@@ -9289,6 +9793,11 @@
         }
       }
     },
+    "node_modules/xsalsa20": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xsalsa20/-/xsalsa20-1.2.0.tgz",
+      "integrity": "sha512-FIr/DEeoHfj7ftfylnoFt3rAIRoWXpx2AoDfrT2qD2wtp7Dp+COajvs/Icb7uHqRW9m60f5iXZwdsJJO3kvb7w=="
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -9411,6 +9920,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z32": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/z32/-/z32-1.0.1.tgz",
+      "integrity": "sha512-Uytfqf6VEVchHKZDw0NRdCViOARHP84uzvOw0CXCMLOwhgHZUL9XibpEPLLQN10mCVLxOlGCQWbkV7km7yNYcw==",
+      "dependencies": {
+        "b4a": "^1.5.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "url": "https://github.com/TBD54566975/dwn-server/issues"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.12",
-    "@tbd54566975/dwn-sql-store": "0.2.6",
+    "@tbd54566975/dwn-sdk-js": "0.2.14",
+    "@tbd54566975/dwn-sql-store": "0.2.8",
     "better-sqlite3": "^8.5.0",
     "body-parser": "^1.20.2",
     "bytes": "3.1.2",

--- a/tests/cors/http-api.browser.ts
+++ b/tests/cors/http-api.browser.ts
@@ -1,8 +1,8 @@
 import {
-  DidKeyResolver,
   RecordsRead,
   RecordsWrite,
   Jws,
+  TestDataGenerator,
 } from '@tbd54566975/dwn-sdk-js';
 
 import { expect } from 'chai';
@@ -13,7 +13,7 @@ describe('http-api', () => {
     // work only under secure context.
     // Test code runs on secure context of http://dwn.localhost
     // by cors setup.
-    const alice = await DidKeyResolver.generate();
+    const alice = await TestDataGenerator.generateDidKeyPersona();
     const encoder = new TextEncoder();
     const data = encoder.encode('Hello, World!');
     const recordsWrite = (

--- a/tests/dwn-process-message.spec.ts
+++ b/tests/dwn-process-message.spec.ts
@@ -1,5 +1,3 @@
-import { DidKeyResolver } from '@tbd54566975/dwn-sdk-js';
-
 import { expect } from 'chai';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -8,10 +6,11 @@ import type { RequestContext } from '../src/lib/json-rpc-router.js';
 import { createJsonRpcRequest } from '../src/lib/json-rpc.js';
 import { getTestDwn } from './test-dwn.js';
 import { createRecordsWriteMessage } from './utils.js';
+import { TestDataGenerator } from '@tbd54566975/dwn-sdk-js';
 
 describe('handleDwnProcessMessage', function () {
   it('returns a JSON RPC Success Response when DWN returns a 2XX status code', async function () {
-    const alice = await DidKeyResolver.generate();
+    const alice = await TestDataGenerator.generateDidKeyPersona();
 
     // Construct a well-formed DWN Request that will be successfully processed.
     const { recordsWrite, dataStream } = await createRecordsWriteMessage(alice);

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -2,9 +2,9 @@
 import {
   Cid,
   DataStream,
-  DidKeyResolver,
   RecordsQuery,
   RecordsRead,
+  TestDataGenerator,
   Time,
 } from '@tbd54566975/dwn-sdk-js';
 import type { Dwn, Persona } from '@tbd54566975/dwn-sdk-js';
@@ -66,7 +66,7 @@ describe('http api', function () {
 
     httpApi = new HttpApi(config, dwn, registrationManager);
 
-    alice = await DidKeyResolver.generate();
+    alice = await TestDataGenerator.generateDidKeyPersona();
     await registrationManager.recordTenantRegistration({ did: alice.did, termsOfServiceHash: registrationManager.getTermsOfServiceHash()});
   });
 
@@ -508,7 +508,7 @@ describe('http api', function () {
     });
 
     it('returns a 404 for invalid or unauthorized did', async function () {
-      const unauthorized = await DidKeyResolver.generate();
+      const unauthorized = await TestDataGenerator.generateDidKeyPersona();
       const { recordsWrite } = await createRecordsWriteMessage(unauthorized);
 
       const response = await fetch(

--- a/tests/scenarios/registration.spec.ts
+++ b/tests/scenarios/registration.spec.ts
@@ -1,8 +1,5 @@
 // node.js 18 and earlier,  needs globalThis.crypto polyfill
-import {
-  DataStream,
-  DidKeyResolver,
-} from '@tbd54566975/dwn-sdk-js';
+import { DataStream, TestDataGenerator } from '@tbd54566975/dwn-sdk-js';
 import type { Persona } from '@tbd54566975/dwn-sdk-js';
 
 import { expect } from 'chai';
@@ -51,7 +48,7 @@ describe('Registration scenarios', function () {
   before(async function () {
     clock = useFakeTimers({ shouldAdvanceTime: true });
 
-    alice = await DidKeyResolver.generate();
+    alice = await TestDataGenerator.generateDidKeyPersona();
 
     // NOTE: using SQL to workaround an issue where multiple instances of DwnServer can be started using LevelDB in the same test run,
     // and dwn-server.spec.ts already uses LevelDB.
@@ -182,7 +179,7 @@ describe('Registration scenarios', function () {
     expect(writeResponseBody.result.reply.status.code).to.equal(202);
 
     // 7. Sanity test that another non-tenant is NOT authorized to write.
-    const nonTenant = await DidKeyResolver.generate();
+    const nonTenant = await TestDataGenerator.generateDidKeyPersona();
     const nonTenantJsonRpcRequest = await generateRecordsWriteJsonRpcRequest(nonTenant);
     const nonTenantJsonRpcResponse = await fetch(dwnMessageEndpoint, {
       method: 'POST',

--- a/tests/ws-api.spec.ts
+++ b/tests/ws-api.spec.ts
@@ -1,4 +1,4 @@
-import { DataStream, DidKeyResolver } from '@tbd54566975/dwn-sdk-js';
+import { DataStream, TestDataGenerator } from '@tbd54566975/dwn-sdk-js';
 
 import { expect } from 'chai';
 import { base64url } from 'multiformats/bases/base64';
@@ -53,7 +53,7 @@ describe('websocket api', function () {
   });
 
   it('handles RecordsWrite messages', async function () {
-    const alice = await DidKeyResolver.generate();
+    const alice = await TestDataGenerator.generateDidKeyPersona();
 
     const { recordsWrite, dataStream } = await createRecordsWriteMessage(alice);
     const dataBytes = await DataStream.toBytes(dataStream);


### PR DESCRIPTION
- Bump `dwn-sdk-js` to `0.2.14` which now uses `@web5/dids`.
- Using `TestDataGenerator` to generate a `did:key` `Persona`.
- Bump `dwn-sql-store` to `0.2.8`