### PR TITLE
Bump `dwn-sdk-js` version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ node_modules
 tmp
 dwn.db
 coverage
+
+RESOLVERCACHE

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@web5/dwn-server",
       "version": "0.1.10",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.16",
+        "@tbd54566975/dwn-sdk-js": "0.2.17",
         "@tbd54566975/dwn-sql-store": "0.2.9",
         "better-sqlite3": "^8.5.0",
         "body-parser": "^1.20.2",
@@ -43,6 +43,7 @@
         "@types/ws": "8.5.4",
         "@typescript-eslint/eslint-plugin": "5.59.0",
         "@typescript-eslint/parser": "5.59.0",
+        "@web5/dids": "0.4.0",
         "c8": "8.0.1",
         "chai": "4.3.6",
         "chai-as-promised": "7.1.1",
@@ -613,15 +614,15 @@
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.16.tgz",
-      "integrity": "sha512-I/LKbqB7Qn2+G4V3b2rbFQcDaXONTcDRNVLszxV7CDlb8cjPIwYv+vjtEtcyWwjwr+KjlOnS6AxvnhZn5sEnTw==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.17.tgz",
+      "integrity": "sha512-i7swoqfKm5/m53yqBMjkiRy4d3usScic6JK/9aiIAQ8BD9iC0mBb6MbAAsOD+Z4QtscVFwHh4qDZCfd0Rp9eQg==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
         "@noble/ed25519": "2.0.0",
         "@noble/secp256k1": "2.0.0",
-        "@web5/dids": "0.3.0",
+        "@web5/dids": "0.4.0",
         "abstract-level": "1.0.3",
         "ajv": "8.12.0",
         "blockstore-core": "4.2.0",
@@ -697,6 +698,111 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.16.tgz",
+      "integrity": "sha512-I/LKbqB7Qn2+G4V3b2rbFQcDaXONTcDRNVLszxV7CDlb8cjPIwYv+vjtEtcyWwjwr+KjlOnS6AxvnhZn5sEnTw==",
+      "dependencies": {
+        "@ipld/dag-cbor": "9.0.3",
+        "@js-temporal/polyfill": "0.4.4",
+        "@noble/ed25519": "2.0.0",
+        "@noble/secp256k1": "2.0.0",
+        "@web5/dids": "0.3.0",
+        "abstract-level": "1.0.3",
+        "ajv": "8.12.0",
+        "blockstore-core": "4.2.0",
+        "cross-fetch": "4.0.0",
+        "eciesjs": "0.4.5",
+        "interface-blockstore": "5.2.3",
+        "interface-store": "5.1.2",
+        "ipfs-unixfs-exporter": "13.1.5",
+        "ipfs-unixfs-importer": "15.1.5",
+        "level": "8.0.0",
+        "lodash": "4.17.21",
+        "lru-cache": "9.1.2",
+        "ms": "2.1.3",
+        "multiformats": "11.0.2",
+        "randombytes": "2.1.0",
+        "readable-stream": "4.5.2",
+        "ulidx": "2.1.0",
+        "uuid": "8.3.2",
+        "varint": "6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.3.tgz",
+      "integrity": "sha512-A2UFccS0+sARK9xwXiVZIaWbLbPxLGP3UZOjBeOMWfDY04SXi8h1+t4rHBzOlKYF/yWNm3RbFLyclWO7hZcy4g==",
+      "dependencies": {
+        "cborg": "^2.0.1",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
+      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/cborg": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.5.tgz",
+      "integrity": "sha512-xVW1rSIw1ZXbkwl2XhJ7o/jAv0vnVoQv/QlfQxV8a7V5PlA4UU/AcIiXqmpyybwNWy/GPQU1m/aBVNIWr7/T0w==",
+      "bin": {
+        "cborg": "cli.js"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/multiformats": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
+      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@web5/dids": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.3.0.tgz",
+      "integrity": "sha512-Y6I/mNkSyjtRxvgTH72DJqcMiCA1ywMVJys09ro//kD0NiFU3NYBulurrFTp/Z4yV4t6KKOq7hj1WopWMagTbQ==",
+      "dependencies": {
+        "@decentralized-identity/ion-sdk": "1.0.1",
+        "@dnsquery/dns-packet": "6.1.1",
+        "@web5/common": "0.2.3",
+        "@web5/crypto": "0.4.0",
+        "bencode": "4.0.0",
+        "level": "8.0.0",
+        "ms": "2.1.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@tbd54566975/dwn-sql-store/node_modules/cborg": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.5.tgz",
@@ -712,6 +818,14 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@tbd54566975/dwn-sql-store/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -1149,9 +1263,9 @@
       }
     },
     "node_modules/@web5/dids": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.3.0.tgz",
-      "integrity": "sha512-Y6I/mNkSyjtRxvgTH72DJqcMiCA1ywMVJys09ro//kD0NiFU3NYBulurrFTp/Z4yV4t6KKOq7hj1WopWMagTbQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.4.0.tgz",
+      "integrity": "sha512-e+QcrKWlWPJVBbpz4QKrdcgPoj+uC8YUXt4tGKj1mC4kV0rCtIioMLw9Djg+54pp3VXl3eGKxju98UEddyZwqA==",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "1.0.1",
         "@dnsquery/dns-packet": "6.1.1",
@@ -2050,9 +2164,9 @@
       }
     },
     "node_modules/classic-level": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.3.0.tgz",
-      "integrity": "sha512-iwFAJQYtqRTRM0F6L8h4JCt00ZSGdOyqh7yVrhhjrOpFhmBjNlRUey64MCiyo6UmQHMJ+No3c81nujPv+n9yrg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.4.1.tgz",
+      "integrity": "sha512-qGx/KJl3bvtOHrGau2WklEZuXhS3zme+jf+fsu6Ej7W7IP/C49v7KNlWIsT1jZu0YnfzSIYDGcEWpCa1wKGWXQ==",
       "hasInstallScript": true,
       "dependencies": {
         "abstract-level": "^1.0.2",
@@ -6765,9 +6879,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
-      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/TBD54566975/dwn-server/issues"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.16",
+    "@tbd54566975/dwn-sdk-js": "0.2.17",
     "@tbd54566975/dwn-sql-store": "0.2.9",
     "better-sqlite3": "^8.5.0",
     "body-parser": "^1.20.2",
@@ -58,6 +58,7 @@
     "@types/ws": "8.5.4",
     "@typescript-eslint/eslint-plugin": "5.59.0",
     "@typescript-eslint/parser": "5.59.0",
+    "@web5/dids": "0.4.0",
     "c8": "8.0.1",
     "chai": "4.3.6",
     "chai-as-promised": "7.1.1",

--- a/tests/dwn-server.spec.ts
+++ b/tests/dwn-server.spec.ts
@@ -1,36 +1,18 @@
 import { expect } from 'chai';
 
-import type { DwnServerConfig } from '../src/config.js';
 import { config } from '../src/config.js';
 import { DwnServer } from '../src/dwn-server.js';
-import { randomBytes } from 'crypto';
+import { getTestDwn } from './test-dwn.js';
 
 describe('DwnServer', function () {
   const dwnServerConfig = { ...config };
   
-  before(async function () {
-    // NOTE: using SQL to workaround an issue where multiple instances of DwnServer can be started using LevelDB in the same test run,
-    // and dwn-server.spec.ts already uses LevelDB.
-    dwnServerConfig.messageStore = 'sqlite://';
-    dwnServerConfig.dataStore = 'sqlite://';
-    dwnServerConfig.eventLog = 'sqlite://';
-  });
 
-  after(async function () {
-  });
+  it('starts with injected dwn', async function () {
+    const testDwn = await getTestDwn();
 
-  it('should initialize ProofOfWorkManager with challenge nonce seed if given.', async function () {
-    const registrationProofOfWorkSeed = randomBytes(32).toString('hex');
-    const configWithProofOfWorkSeed: DwnServerConfig = {
-      ...dwnServerConfig,
-      registrationStoreUrl: 'sqlite://',
-      registrationProofOfWorkEnabled: true,
-      registrationProofOfWorkSeed
-    };
-
-    const dwnServer = new DwnServer({ config: configWithProofOfWorkSeed });
+    const dwnServer = new DwnServer({ config: dwnServerConfig, dwn: testDwn });
     await dwnServer.start();
-    expect(dwnServer.registrationManager['proofOfWorkManager']['challengeSeed']).to.equal(registrationProofOfWorkSeed);
 
     dwnServer.stop(() => console.log('server Stop'));
     expect(dwnServer.httpServer.listening).to.be.false;

--- a/tests/scenarios/registration.spec.ts
+++ b/tests/scenarios/registration.spec.ts
@@ -533,7 +533,8 @@ describe('Registration scenarios', function () {
   });
 
   /**
-   * NOTE: The tests below instantiate their own server configs and should should take care to stop the original server
+   * NOTE: The tests below instantiate their own server configs and should should take care to stop the `dwnServer`
+   * This is done to avoid LevelDB locking for the default `DidResolver` cache.
    */
 
   it('should initialize ProofOfWorkManager with challenge nonce seed if given.', async function () {

--- a/tests/test-dwn.ts
+++ b/tests/test-dwn.ts
@@ -7,10 +7,17 @@ import {
 } from '@tbd54566975/dwn-sql-store';
 
 import { getDialectFromURI } from '../src/storage.js';
+import { DidDht, DidIon, DidKey, DidResolver } from '@web5/dids';
 
 export async function getTestDwn(
   tenantGate?: TenantGate
 ): Promise<Dwn> {
+
+  // NOTE: no resolver cache used here to avoid locking LevelDB
+  const didResolver = new DidResolver({
+    didResolvers : [DidDht, DidIon, DidKey],
+  });
+
   const db = getDialectFromURI(new URL('sqlite://'));
   const dataStore = new DataStoreSql(db);
   const eventLog = new EventLogSql(db);
@@ -22,7 +29,8 @@ export async function getTestDwn(
       eventLog,
       dataStore,
       messageStore,
-      tenantGate
+      tenantGate,
+      didResolver
     });
   } catch (e) {
     throw e;


### PR DESCRIPTION
- bump `dwn-sdk-js` to `0.2.17` which include the new `@web5/dids` package.
- Injecting the `DidResolver` from `@web5/dids` without caching in tests is to prevent LevelDB from locking.