### PR TITLE
Bump to v0.1.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@web5/dwn-server",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@web5/dwn-server",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.17",
-        "@tbd54566975/dwn-sql-store": "0.2.9",
+        "@tbd54566975/dwn-sdk-js": "0.2.18",
+        "@tbd54566975/dwn-sql-store": "0.2.10",
         "better-sqlite3": "^8.5.0",
         "body-parser": "^1.20.2",
         "bytes": "3.1.2",
@@ -43,7 +43,7 @@
         "@types/ws": "8.5.4",
         "@typescript-eslint/eslint-plugin": "5.59.0",
         "@typescript-eslint/parser": "5.59.0",
-        "@web5/dids": "0.4.0",
+        "@web5/dids": "0.4.1",
         "c8": "8.0.1",
         "chai": "4.3.6",
         "chai-as-promised": "7.1.1",
@@ -614,15 +614,15 @@
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.17.tgz",
-      "integrity": "sha512-i7swoqfKm5/m53yqBMjkiRy4d3usScic6JK/9aiIAQ8BD9iC0mBb6MbAAsOD+Z4QtscVFwHh4qDZCfd0Rp9eQg==",
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.18.tgz",
+      "integrity": "sha512-71K8izqimtsforMBISl4s8VR5El6VtZd6xjs/s7eYsOww3H/wbdVC5KBXeCvGDlfBoTOk62R5eEUm+WEgaOMrw==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
         "@noble/ed25519": "2.0.0",
         "@noble/secp256k1": "2.0.0",
-        "@web5/dids": "0.4.0",
+        "@web5/dids": "0.4.1",
         "abstract-level": "1.0.3",
         "ajv": "8.12.0",
         "blockstore-core": "4.2.0",
@@ -671,12 +671,12 @@
       }
     },
     "node_modules/@tbd54566975/dwn-sql-store": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.9.tgz",
-      "integrity": "sha512-D4iKH9qqT43OXkc6tjBabj97z/PoF+zY3cF0W0SyPedEhN+t+jxHG6F+XRqCiqzqPu58wp4kuD4HPErAWWWMDg==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.10.tgz",
+      "integrity": "sha512-x3tTosQFBwn2Ltqj2FZ84Ma297ekUFeXSyOSfhO6rMHexU1RNmSvuV3YBLfDpBWZUr0ffF1GiJ6zMHKXdoF2jw==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.2.16",
+        "@tbd54566975/dwn-sdk-js": "0.2.18",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"
@@ -698,111 +698,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.16.tgz",
-      "integrity": "sha512-I/LKbqB7Qn2+G4V3b2rbFQcDaXONTcDRNVLszxV7CDlb8cjPIwYv+vjtEtcyWwjwr+KjlOnS6AxvnhZn5sEnTw==",
-      "dependencies": {
-        "@ipld/dag-cbor": "9.0.3",
-        "@js-temporal/polyfill": "0.4.4",
-        "@noble/ed25519": "2.0.0",
-        "@noble/secp256k1": "2.0.0",
-        "@web5/dids": "0.3.0",
-        "abstract-level": "1.0.3",
-        "ajv": "8.12.0",
-        "blockstore-core": "4.2.0",
-        "cross-fetch": "4.0.0",
-        "eciesjs": "0.4.5",
-        "interface-blockstore": "5.2.3",
-        "interface-store": "5.1.2",
-        "ipfs-unixfs-exporter": "13.1.5",
-        "ipfs-unixfs-importer": "15.1.5",
-        "level": "8.0.0",
-        "lodash": "4.17.21",
-        "lru-cache": "9.1.2",
-        "ms": "2.1.3",
-        "multiformats": "11.0.2",
-        "randombytes": "2.1.0",
-        "readable-stream": "4.5.2",
-        "ulidx": "2.1.0",
-        "uuid": "8.3.2",
-        "varint": "6.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.0.3.tgz",
-      "integrity": "sha512-A2UFccS0+sARK9xwXiVZIaWbLbPxLGP3UZOjBeOMWfDY04SXi8h1+t4rHBzOlKYF/yWNm3RbFLyclWO7hZcy4g==",
-      "dependencies": {
-        "cborg": "^2.0.1",
-        "multiformats": "^12.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/@ipld/dag-cbor/node_modules/multiformats": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.3.tgz",
-      "integrity": "sha512-eajQ/ZH7qXZQR2AgtfpmSMizQzmyYVmCql7pdhldPuYQi4atACekbJaQplk6dWyIi10jCaFnd6pqvcEFXjbaJw==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/cborg": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-2.0.5.tgz",
-      "integrity": "sha512-xVW1rSIw1ZXbkwl2XhJ7o/jAv0vnVoQv/QlfQxV8a7V5PlA4UU/AcIiXqmpyybwNWy/GPQU1m/aBVNIWr7/T0w==",
-      "bin": {
-        "cborg": "cli.js"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/multiformats": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
-      "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@tbd54566975/dwn-sdk-js/node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/@web5/dids": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.3.0.tgz",
-      "integrity": "sha512-Y6I/mNkSyjtRxvgTH72DJqcMiCA1ywMVJys09ro//kD0NiFU3NYBulurrFTp/Z4yV4t6KKOq7hj1WopWMagTbQ==",
-      "dependencies": {
-        "@decentralized-identity/ion-sdk": "1.0.1",
-        "@dnsquery/dns-packet": "6.1.1",
-        "@web5/common": "0.2.3",
-        "@web5/crypto": "0.4.0",
-        "bencode": "4.0.0",
-        "level": "8.0.0",
-        "ms": "2.1.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@tbd54566975/dwn-sql-store/node_modules/cborg": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.5.tgz",
@@ -818,14 +713,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@tbd54566975/dwn-sql-store/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -1263,9 +1150,9 @@
       }
     },
     "node_modules/@web5/dids": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.4.0.tgz",
-      "integrity": "sha512-e+QcrKWlWPJVBbpz4QKrdcgPoj+uC8YUXt4tGKj1mC4kV0rCtIioMLw9Djg+54pp3VXl3eGKxju98UEddyZwqA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.4.1.tgz",
+      "integrity": "sha512-EY55euXdDfdFMef2k8DeOrGmStBRhwvoai/JuJbUdCGDpvgwdoZWXPkGEkFr4VZQsfR7R7rNFMlsYw3VRPUVJw==",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "1.0.1",
         "@dnsquery/dns-packet": "6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@web5/dwn-server",
   "type": "module",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "files": [
     "dist",
     "src"
@@ -26,8 +26,8 @@
     "url": "https://github.com/TBD54566975/dwn-server/issues"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.17",
-    "@tbd54566975/dwn-sql-store": "0.2.9",
+    "@tbd54566975/dwn-sdk-js": "0.2.18",
+    "@tbd54566975/dwn-sql-store": "0.2.10",
     "better-sqlite3": "^8.5.0",
     "body-parser": "^1.20.2",
     "bytes": "3.1.2",
@@ -58,7 +58,7 @@
     "@types/ws": "8.5.4",
     "@typescript-eslint/eslint-plugin": "5.59.0",
     "@typescript-eslint/parser": "5.59.0",
-    "@web5/dids": "0.4.0",
+    "@web5/dids": "0.4.1",
     "c8": "8.0.1",
     "chai": "4.3.6",
     "chai-as-promised": "7.1.1",


### PR DESCRIPTION
- upgrades `dwn-sdk-js` to `v0.2.18`
- upgrades `dwn-sql-store` to `v0.2.10`
- upgrades `@web5/dids` to `v0.4.1` in dev dependencies
- bump version to `v0.1.11`