### PR TITLE
enhance info endpoint and bump to `v0.1.13`

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ the server exposes information about itself via the `/info` endpoint, which retu
   "maxFileSize": 1073741824,
   "registrationRequirements": ["proof-of-work-sha256-v0", "terms-of-service"],
   "version": "0.1.5",
-  "sdkVersion": "0.2.6"
+  "sdkVersion": "0.2.6",
+  "webSocketSupport": "true"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -325,3 +325,6 @@ the server exposes information about itself via the `/info` endpoint, which retu
   "webSocketSupport": "true"
 }
 ```
+
+- `server` is read from the `process.env.npm_package_name` variable that `npm` provides. If that does not exist, it will check for a `DWN_SERVER_PACKAGE_NAME` environment variable set by the user, or otherwise it will default to `@web5/dwn-server`.
+- `version` and `sdkVersion` are read from the `package.json` file. It will locate the file's path either from the `process.env.npm_package_json` variable that `npm` provides. If that does not exist, it will check for a `DWN_SERVER_PACKAGE_JSON` environment variable set by the user, or otherwise it will default to `/dwn-server/package.json` which is the path within the default Docker container build.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@web5/dwn-server",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@web5/dwn-server",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@tbd54566975/dwn-sdk-js": "0.2.18",
         "@tbd54566975/dwn-sql-store": "0.2.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@web5/dwn-server",
   "type": "module",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "files": [
     "dist",
     "src"

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,8 @@ import bytes from 'bytes';
 export type DwnServerConfig = typeof config;
 
 export const config = {
+  serverName: process.env.DWN_SERVER_PACKAGE_NAME || '@web5/dwn-server',
+  packageJsonFile:  process.env.npm_package_json ||  process.env.DWN_SERVER_PACKAGE_JSON || '/dwn-server/package.json',
   // max size of data that can be provided with a RecordsWrite
   maxRecordDataSize: bytes(process.env.MAX_RECORD_DATA_SIZE || '1gb'),
   // port that server listens on

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,10 +3,22 @@ import bytes from 'bytes';
 export type DwnServerConfig = typeof config;
 
 export const config = {
-  // the `server` property returned by the `/info` endpoint.
-  serverName: process.env.DWN_SERVER_PACKAGE_NAME || '@web5/dwn-server',
-  // used to populate the `version` and `sdkVersion` properties returned by the `/info` endpoint.
-  packageJsonFile:  process.env.npm_package_json ||  process.env.DWN_SERVER_PACKAGE_JSON || '/dwn-server/package.json',
+  /**
+   * Used to populate the `server` property returned by the `/info` endpoint.
+   *
+   * If running using `npm` the `process.env.npm_package_name` variable exists and we use that,
+   * otherwise we fall back on the use defined `DWN_SERVER_PACKAGE_NAME` or `@web5/dwn-server`.
+   */
+  serverName: process.env.npm_package_name || process.env.DWN_SERVER_PACKAGE_NAME || '@web5/dwn-server',
+  /**
+   * Used to populate the `version` and `sdkVersion` properties returned by the `/info` endpoint.
+   *
+   * The `version` and `sdkVersion` are pulled from `package.json` at runtime.
+   * If running using `npm` the `process.env.npm_package_json` variable exists as the filepath, so we use that.
+   * Otherwise we check to see if a specific `DWN_SERVER_PACKAGE_JSON` exists, if it does we use that.
+   * Finally if both of those options don't exist we resort to the path within the docker server image, located at `/dwn-server/package.json`
+   */
+  packageJsonPath:  process.env.npm_package_json ||  process.env.DWN_SERVER_PACKAGE_JSON || '/dwn-server/package.json',
   // max size of data that can be provided with a RecordsWrite
   maxRecordDataSize: bytes(process.env.MAX_RECORD_DATA_SIZE || '1gb'),
   // port that server listens on

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,9 @@ import bytes from 'bytes';
 export type DwnServerConfig = typeof config;
 
 export const config = {
+  // the `server` property returned by the `/info` endpoint.
   serverName: process.env.DWN_SERVER_PACKAGE_NAME || '@web5/dwn-server',
+  // used to populate the `version` and `sdkVersion` properties returned by the `/info` endpoint.
   packageJsonFile:  process.env.npm_package_json ||  process.env.DWN_SERVER_PACKAGE_JSON || '/dwn-server/package.json',
   // max size of data that can be provided with a RecordsWrite
   maxRecordDataSize: bytes(process.env.MAX_RECORD_DATA_SIZE || '1gb'),

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -37,12 +37,9 @@ export class HttpApi {
       server: config.serverName,
     };
     
-    // Server and SDK versions are pulled from `package.json` at runtime.
-    // If running using `npm` the `process.env.npm_package_json` variable exists as the filepath, so we use that.
-    // Otherwise we check to see if a specific `DWN_SERVER_PACKAGE_JSON` exists, if it does we use that.
-    // Finally if both of those options don't exist we resort to the path within the docker server image, located at `/dwn-server/package.json`
     try {
-      const packageJson = JSON.parse(readFileSync(config.packageJsonFile).toString());
+      // We populate the `version` and `sdkVersion` properties from the `package.json` file.
+      const packageJson = JSON.parse(readFileSync(config.packageJsonPath).toString());
       this.#packageInfo.version = packageJson.version;
       this.#packageInfo.sdkVersion = packageJson.dependencies ? packageJson.dependencies['@tbd54566975/dwn-sdk-js'] : undefined;
     } catch (error: any) {

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -21,7 +21,16 @@ import { jsonRpcRouter } from './json-rpc-api.js';
 import { requestCounter, responseHistogram } from './metrics.js';
 import type { RegistrationManager } from './registration/registration-manager.js';
 
-const packageJson = process.env.npm_package_json ? JSON.parse(readFileSync(process.env.npm_package_json).toString()) : {};
+const packageJson = process.env.npm_package_json ? JSON.parse(readFileSync(process.env.npm_package_json).toString()) : {
+  dependencies: {}
+};
+
+// when this server runs as a docker container, it is not run using the `npm` package, so `npm_package_json` env does not exist.
+// we inject the versions using the respective environment variables.
+const packageVersions = {
+  version    : packageJson.version || process.env.DWN_VERSION,
+  sdkVersion : packageJson.dependencies['@tbd54566975/dwn-sdk-js'] || process.env.DWN_SDK_VERSION
+}
 
 export class HttpApi {
   #config: DwnServerConfig;
@@ -188,8 +197,8 @@ export class HttpApi {
         server                   : process.env.npm_package_name,
         maxFileSize              : config.maxRecordDataSize,
         registrationRequirements : registrationRequirements,
-        version                  : packageJson.version,
-        sdkVersion               : packageJson.dependencies['@tbd54566975/dwn-sdk-js'],
+        version                  : packageVersions.version,
+        sdkVersion               : packageVersions.sdkVersion,
         webSocketSupport         : config.webSocketSupport,
       });
     });

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -28,7 +28,7 @@ const packageJson = process.env.npm_package_json ? JSON.parse(readFileSync(proce
 // when this server runs as a docker container, it is not run using the `npm` package, so `npm_package_json` env does not exist.
 // we inject the versions using the respective environment variables.
 const packageVersions = {
-  version    : packageJson.version || process.env.DWN_VERSION,
+  version    : packageJson.version || process.env.DWN_SERVER_VERSION,
   sdkVersion : packageJson.dependencies['@tbd54566975/dwn-sdk-js'] || process.env.DWN_SDK_VERSION
 }
 

--- a/src/json-rpc-handlers/dwn/process-message.ts
+++ b/src/json-rpc-handlers/dwn/process-message.ts
@@ -115,7 +115,7 @@ export const handleDwnProcessMessage: JsonRpcHandler = async (
     );
 
     // log the unhandled error response
-    log.error('handleDwnProcessMessage error', jsonRpcResponse, e);
+    log.error('handleDwnProcessMessage error', jsonRpcResponse, dwnRequest, e);
     return { jsonRpcResponse } as HandlerResponse;
   }
 };

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -574,8 +574,10 @@ describe('http api', function () {
       server.close();
       server.closeAllConnections();
 
+      // set up spy to check for an error log by the server
       const logSpy = sinon.spy(log, 'error');
 
+      // set the config to an invalid file path
       const packageJsonConfig = config.packageJsonFile;
       config.packageJsonFile = '/some/invalid/file.json';
       httpApi = new HttpApi(config, dwn, registrationManager);
@@ -584,10 +586,17 @@ describe('http api', function () {
       const resp = await fetch(`http://localhost:3000/info`);
       const info = await resp.json();
       expect(resp.status).to.equal(200);
+
+      // check that server name exists in the info object
       expect(info['server']).to.equal('@web5/dwn-server');
+
+      // check that `sdkVersion` and `version` are undefined as they were not abel to be retrieved from the invalid file.
       expect(info['sdkVersion']).to.be.undefined;
       expect(info['version']).to.be.undefined;
+
+      // check the logSpy was called
       expect(logSpy.callCount).to.equal(1);
+      expect(logSpy.args[0][0]).to.contain('could not read `package.json` for version info');
 
       // restore old config path
       config.packageJsonFile = packageJsonConfig;
@@ -597,6 +606,7 @@ describe('http api', function () {
       server.close();
       server.closeAllConnections();
 
+      // set a custom name for the `serverName`
       const serverName = config.serverName;
       config.serverName = '@web5/dwn-server-2'
       httpApi = new HttpApi(config, dwn, registrationManager);
@@ -605,7 +615,11 @@ describe('http api', function () {
       const resp = await fetch(`http://localhost:3000/info`);
       const info = await resp.json();
       expect(resp.status).to.equal(200);
+      
+      // verify that the custom server name was passed to the info endpoint
       expect(info['server']).to.equal('@web5/dwn-server-2');
+
+      // verify that `sdkVersion` and `version` exist.
       expect(info['sdkVersion']).to.not.be.undefined;
       expect(info['version']).to.not.be.undefined;
 

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -578,8 +578,8 @@ describe('http api', function () {
       const logSpy = sinon.spy(log, 'error');
 
       // set the config to an invalid file path
-      const packageJsonConfig = config.packageJsonFile;
-      config.packageJsonFile = '/some/invalid/file.json';
+      const packageJsonConfig = config.packageJsonPath;
+      config.packageJsonPath = '/some/invalid/file.json';
       httpApi = new HttpApi(config, dwn, registrationManager);
       server = await httpApi.start(3000);
 
@@ -599,7 +599,7 @@ describe('http api', function () {
       expect(logSpy.args[0][0]).to.contain('could not read `package.json` for version info');
 
       // restore old config path
-      config.packageJsonFile = packageJsonConfig;
+      config.packageJsonPath = packageJsonConfig;
     });
 
     it('verify /info returns server name from config', async function () {


### PR DESCRIPTION
In a previous PR some(much desired) version information was added to the `/info` endpoint, however in certain environments(our docker container) this blows up.

This PR prevents the endpoint from blowing up, while also providing some optionality and defaults to fall back on and bumps version to `v0.1.13`

Added the text below to the `README.md` file:

- `server` is read from the `process.env.npm_package_name` variable that `npm` provides. If that does not exist, it will check for a `DWN_SERVER_PACKAGE_NAME` environment variable set by the user, or otherwise it will default to `@web5/dwn-server`.
- `version` and `sdkVersion` are read from the `package.json` file. It will locate the file's path either from the `process.env.npm_package_json` variable that `npm` provides. If that does not exist, it will check for a `DWN_SERVER_PACKAGE_JSON` environment variable set by the user, or otherwise it will default to `/dwn-server/package.json` which is the path within the default Docker container build.