### PR TITLE
bump dwn-sdk-js and dnw-sql-store deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@web5/dwn-server",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@web5/dwn-server",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.20",
-        "@tbd54566975/dwn-sql-store": "0.2.11",
+        "@tbd54566975/dwn-sdk-js": "0.2.21",
+        "@tbd54566975/dwn-sql-store": "0.2.12",
         "better-sqlite3": "^8.5.0",
         "body-parser": "^1.20.2",
         "bytes": "3.1.2",
@@ -45,7 +45,7 @@
         "@types/ws": "8.5.4",
         "@typescript-eslint/eslint-plugin": "5.59.0",
         "@typescript-eslint/parser": "5.59.0",
-        "@web5/dids": "0.4.2",
+        "@web5/dids": "0.4.3",
         "c8": "8.0.1",
         "chai": "4.3.6",
         "chai-as-promised": "7.1.1",
@@ -357,6 +357,14 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@isaacs/ttlcache": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
+      "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -616,15 +624,15 @@
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.20.tgz",
-      "integrity": "sha512-r8yhWZC24Ctljh9cEnsVemNsmcINthn+EZlt6Ff22Ja/8JubQZC3Q5wOjKe1eoCaBvumt3ep2ke/+qzt5YkrrQ==",
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.21.tgz",
+      "integrity": "sha512-rave+6mwn2/YBYu5LRwDWaOxvHV51DdMO6OFCLC3gJVOiAAYCmtPlebpdVCanBzqhWITh2qPcIZa7BefoxOPmQ==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
         "@noble/ed25519": "2.0.0",
         "@noble/secp256k1": "2.0.0",
-        "@web5/dids": "0.4.2",
+        "@web5/dids": "0.4.3",
         "abstract-level": "1.0.3",
         "ajv": "8.12.0",
         "blockstore-core": "4.2.0",
@@ -673,12 +681,12 @@
       }
     },
     "node_modules/@tbd54566975/dwn-sql-store": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.11.tgz",
-      "integrity": "sha512-SY4pQhs1x4iesxGmIHsKBHMlPQFzLIo3JUle50BkoXMgw6WcBSW3Tum0T+X/RHWFPYJ7S2kXB6K6EuyYbT5hMw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.12.tgz",
+      "integrity": "sha512-URcxrgRWTW7et5EH3+P5vK9qp2pmzwq9Yvrp8GRdWG8pwmBZ+poku2QSICE6E3liVYimaI1QDC/7/F2XJbRwhg==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.2.20",
+        "@tbd54566975/dwn-sdk-js": "0.2.21",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"
@@ -1141,10 +1149,11 @@
       }
     },
     "node_modules/@web5/common": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.3.tgz",
-      "integrity": "sha512-WTbIS6l5inrQTS5cwOoQP5KEuUHZqOWCKCDAA62qGUn4QyySolog9Gt2HCNUEClIzzk/d5DHcpBgLCadHoJ6rQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@web5/common/-/common-0.2.4.tgz",
+      "integrity": "sha512-h7I+FbAzTbkQWnv5RZCtE1lFsOzwssvcr4aQuQvO1mx8qTjzl5gGXhFIpl6JB9aSE2FayNUV6kQBID8Sb5HXTQ==",
       "dependencies": {
+        "@isaacs/ttlcache": "1.4.1",
         "level": "8.0.0",
         "multiformats": "11.0.2",
         "readable-stream": "4.4.2"
@@ -1154,14 +1163,14 @@
       }
     },
     "node_modules/@web5/crypto": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.4.0.tgz",
-      "integrity": "sha512-GIKn2CizQKeATvHQqmC4ky26b3q2pJOd2GjIYsOSw/3Y3QIEm3holDGqu9FHs6kacmr6u0Pv5ELvccs58+cKEg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@web5/crypto/-/crypto-0.4.1.tgz",
+      "integrity": "sha512-23LxbdnpTnHBfspqin2L+qy0UKPgdx212SUg6K1pgj2oTvP7gyCKDOyN6yJ4HhexlT0AQxZ6TJ5reoTVn8Cu+g==",
       "dependencies": {
         "@noble/ciphers": "0.4.1",
         "@noble/curves": "1.3.0",
         "@noble/hashes": "1.3.3",
-        "@web5/common": "0.2.3"
+        "@web5/common": "0.2.4"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -1176,14 +1185,14 @@
       }
     },
     "node_modules/@web5/dids": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.4.2.tgz",
-      "integrity": "sha512-HcNrt3jgucLKOppnDuiHCuR1DFX8RXl/ylm1xHafBu1i7qA4MERtrJIE0Qn80SdBwOepjlo8AsYNh9FdpoWYmg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-0.4.3.tgz",
+      "integrity": "sha512-VyTG8dY7iY3j8O055/wBFoGU5Xu1rwTF0RJpFazUE/6W3IuZEYAFTNl2mZ5KSuNRDT1f0VcwebuXW9PbzGuAaw==",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "1.0.1",
         "@dnsquery/dns-packet": "6.1.1",
-        "@web5/common": "0.2.3",
-        "@web5/crypto": "0.4.0",
+        "@web5/common": "0.2.4",
+        "@web5/crypto": "0.4.1",
         "abstract-level": "1.0.4",
         "bencode": "4.0.0",
         "buffer": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@web5/dwn-server",
   "type": "module",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "files": [
     "dist",
     "src"
@@ -26,8 +26,8 @@
     "url": "https://github.com/TBD54566975/dwn-server/issues"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.20",
-    "@tbd54566975/dwn-sql-store": "0.2.11",
+    "@tbd54566975/dwn-sdk-js": "0.2.21",
+    "@tbd54566975/dwn-sql-store": "0.2.12",
     "better-sqlite3": "^8.5.0",
     "body-parser": "^1.20.2",
     "bytes": "3.1.2",
@@ -60,7 +60,7 @@
     "@types/ws": "8.5.4",
     "@typescript-eslint/eslint-plugin": "5.59.0",
     "@typescript-eslint/parser": "5.59.0",
-    "@web5/dids": "0.4.2",
+    "@web5/dids": "0.4.3",
     "c8": "8.0.1",
     "chai": "4.3.6",
     "chai-as-promised": "7.1.1",


### PR DESCRIPTION
- bump `dwn-sdk-js` dep to `0.2.21`
- bump `dwn-sql-store` dep to `0.2.12`
- bump `@web5/dids` dev dep to `0.4.3`
- bump package version to `0.1.15`