### PR TITLE
Upgrade packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@web5/dwn-server",
-  "version": "0.1.17",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@web5/dwn-server",
-      "version": "0.1.17",
+      "version": "0.2.0",
       "dependencies": {
-        "@tbd54566975/dwn-sdk-js": "0.2.22",
-        "@tbd54566975/dwn-sql-store": "0.2.13",
+        "@tbd54566975/dwn-sdk-js": "0.3.0",
+        "@tbd54566975/dwn-sql-store": "0.4.0",
         "better-sqlite3": "^8.5.0",
         "body-parser": "^1.20.2",
         "bytes": "3.1.2",
@@ -19,7 +19,7 @@
         "loglevel": "^1.8.1",
         "loglevel-plugin-prefix": "^0.8.4",
         "multiformats": "11.0.2",
-        "mysql2": "^3.6.0",
+        "mysql2": "^3.9.7",
         "node-fetch": "3.3.1",
         "pg": "^8.11.2",
         "pg-cursor": "^2.10.2",
@@ -45,7 +45,7 @@
         "@types/ws": "8.5.4",
         "@typescript-eslint/eslint-plugin": "5.59.0",
         "@typescript-eslint/parser": "5.59.0",
-        "@web5/dids": "1.0.0",
+        "@web5/dids": "1.0.1",
         "c8": "8.0.1",
         "chai": "4.3.6",
         "chai-as-promised": "7.1.1",
@@ -624,15 +624,15 @@
       "dev": true
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.2.22.tgz",
-      "integrity": "sha512-TBobNAWt09bsAKADiiWNcdgiuuWNkHAumPvuYM9d+V/Brcl99Q9jg3ssVQhMfhV3TN8zxCbAGWYALUfxgX4N3w==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.3.0.tgz",
+      "integrity": "sha512-z/rjPYDfo0kV2eTVi6ElQ+oh7NXaEynrz2YvH1/45jtcsKqi3yQkjOS8HTJJpLVm33pRy5eK/vectJ3uMm4HMQ==",
       "dependencies": {
         "@ipld/dag-cbor": "9.0.3",
         "@js-temporal/polyfill": "0.4.4",
         "@noble/ed25519": "2.0.0",
         "@noble/secp256k1": "2.0.0",
-        "@web5/dids": "1.0.0",
+        "@web5/dids": "1.0.1",
         "abstract-level": "1.0.3",
         "ajv": "8.12.0",
         "blockstore-core": "4.2.0",
@@ -681,12 +681,12 @@
       }
     },
     "node_modules/@tbd54566975/dwn-sql-store": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.2.13.tgz",
-      "integrity": "sha512-TYl16RwExcasH1UTNEQDwcGJbDA96hYQ4iVdpJc7xVfwGwtLzJWR1jSkCugP3BbLJ7lPPy0pywysZ1fW4b/bJg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sql-store/-/dwn-sql-store-0.4.0.tgz",
+      "integrity": "sha512-l6joP9mjs/iRdoYHrIAhIQYgXJ8gr/Uj2oXu5hsUnUphf1CbS/9RngMjZSw37Z8mgk56QJAWKzBlHNA5lrs/nw==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
-        "@tbd54566975/dwn-sdk-js": "0.2.22",
+        "@tbd54566975/dwn-sdk-js": "0.3.0",
         "kysely": "0.26.3",
         "multiformats": "12.0.1",
         "readable-stream": "4.4.2"
@@ -1185,9 +1185,9 @@
       }
     },
     "node_modules/@web5/dids": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-1.0.0.tgz",
-      "integrity": "sha512-TJPRyNIuS50Za3qMHBgNDgwbJQUcVVWXm3Uc3UsDtZIpTLjYb+4LRaynlKzjRPAOR44Q185a+59//5Lyffon+Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@web5/dids/-/dids-1.0.1.tgz",
+      "integrity": "sha512-bAc+zwTDPvtFtd8T25XD0oUmSOBmeTpYSZyBz9w/EqZPKtZOFSc5oFS5qLtrh4YDkkcBqTG5ENQlE9fXs56zIQ==",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "1.0.1",
         "@dnsquery/dns-packet": "6.1.1",
@@ -6593,9 +6593,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.6.3.tgz",
-      "integrity": "sha512-qYd/1CDuW1KYZjD4tzg2O8YS3X/UWuGH8ZMHyMeggMTXL3yOdMisbwZ5SNkHzDGlZXKYLAvV8tMrEH+NUMz3fw==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.7.tgz",
+      "integrity": "sha512-KnJT8vYRcNAZv73uf9zpXqNbvBG7DJrs+1nACsjZP1HMJ1TgXEy8wnNilXAn/5i57JizXKtrUtwDB7HxT9DDpw==",
       "dependencies": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@web5/dwn-server",
   "type": "module",
-  "version": "0.1.17",
+  "version": "0.2.0",
   "files": [
     "dist",
     "src"
@@ -26,8 +26,8 @@
     "url": "https://github.com/TBD54566975/dwn-server/issues"
   },
   "dependencies": {
-    "@tbd54566975/dwn-sdk-js": "0.2.22",
-    "@tbd54566975/dwn-sql-store": "0.2.13",
+    "@tbd54566975/dwn-sdk-js": "0.3.0",
+    "@tbd54566975/dwn-sql-store": "0.4.0",
     "better-sqlite3": "^8.5.0",
     "body-parser": "^1.20.2",
     "bytes": "3.1.2",
@@ -37,7 +37,7 @@
     "loglevel": "^1.8.1",
     "loglevel-plugin-prefix": "^0.8.4",
     "multiformats": "11.0.2",
-    "mysql2": "^3.6.0",
+    "mysql2": "^3.9.7",
     "node-fetch": "3.3.1",
     "pg": "^8.11.2",
     "pg-cursor": "^2.10.2",
@@ -60,7 +60,7 @@
     "@types/ws": "8.5.4",
     "@typescript-eslint/eslint-plugin": "5.59.0",
     "@typescript-eslint/parser": "5.59.0",
-    "@web5/dids": "1.0.0",
+    "@web5/dids": "1.0.1",
     "c8": "8.0.1",
     "chai": "4.3.6",
     "chai-as-promised": "7.1.1",


### PR DESCRIPTION
- upgrade `dwn-sdk-js` to `v0.3.0`
- upgrade `dwn-sql-store` to `v0.4.0`
- upgrade `mysql2` to `3.9.7` -- critical CVE fix
- bump package to `v0.2.0` -- represent breaking changes for the DB schema