### PR TITLE
Update docker image generation script + minor update to README

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -58,6 +58,7 @@ jobs:
           dwn_sdk_version_tag_name=${{ env.REGISTRY }}/${IMAGE_NAME,,}:dwn-sdk-$dwn_sdk_version
 
           # write the image tag names to the step output for use later/below
+          echo "dwn_server_version_tag_name=$dwn_server_version_tag_name" >> $GITHUB_OUTPUT
           echo "dwn_sdk_version_tag_name=$dwn_sdk_version_tag_name" >> $GITHUB_OUTPUT
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -42,10 +42,23 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Retrieve DWN SDK version
+      - name: Create DWN Server docker image tag names
+        id: create_docker_image_tag_names
         run: |
-          echo "dwn_sdk_image_tag=${{ env.REGISTRY }}/${IMAGE_NAME,,}:dwn-sdk-$(jq -r '.dependencies."@tbd54566975/dwn-sdk-js"' package.json)" >> $GITHUB_OUTPUT
-        id: dwn_sdk_version
+          # extract the DWN Server version from the package.json
+          dwn_server_version=$(jq -r '.version' package.json)
+
+          # extract the DWN SDK version from the package.json
+          dwn_sdk_version=$(jq -r '.dependencies."@tbd54566975/dwn-sdk-js"' package.json)
+
+          # construct a image tag names using DWN server & DWN SDK versions
+          # (e.g. ghcr.io/tbd54566975/dwn-server:0.4.3)
+          # (e.g. ghcr.io/tbd54566975/dwn-server:dwn-sdk-0.4.4)
+          dwn_server_version_tag_name=${{ env.REGISTRY }}/${IMAGE_NAME,,}:$dwn_server_version
+          dwn_sdk_version_tag_name=${{ env.REGISTRY }}/${IMAGE_NAME,,}:dwn-sdk-$dwn_sdk_version
+
+          # write the image tag names to the step output for use later/below
+          echo "dwn_sdk_version_tag_name=$dwn_sdk_version_tag_name" >> $GITHUB_OUTPUT
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
 
@@ -57,5 +70,6 @@ jobs:
           push: true
           tags: |
             ${{ steps.meta.outputs.tags }}
-            ${{ steps.dwn_sdk_version.outputs.dwn_sdk_image_tag }}
+            ${{ steps.create_docker_image_tag_names.outputs.dwn_server_version_tag_name }}
+            ${{ steps.create_docker_image_tag_names.outputs.dwn_sdk_version_tag_name }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:18-buster
+# NOTE: `bookworm` is 2024-06-29 v12.6 release of Debian OS
+#       `slim` is a leaner image, optimized for production.
+FROM node:20-bookworm-slim
 
 ARG DS_PORT
 ENV DS_PORT=${DS_PORT:-3000}

--- a/README.md
+++ b/README.md
@@ -276,24 +276,24 @@ cloudflared tunnel --url http://localhost:3000
 
 Configuration can be set using environment variables
 
-| Env Var                                           | Description                                                                                                             | Default                |
-| ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `DS_PORT`                                         | Port that the server listens on                                                                                         | `3000`                 |
-| `DS_MAX_RECORD_DATA_SIZE`                         | Maximum size for `RecordsWrite` data. use `b`, `kb`, `mb`, `gb` for value                                               | `1gb`                  |
-| `DS_WEBSOCKET_SERVER`                             | Whether to enable listening over `ws:`. values: `on`,`off`                                                              | `on`                   |
-| `DWN_BASE_URL`                                    | Base external URL of this DWN. Used to construct URL paths such as the `Request URI` for the Web5 Connect flow.         | `http://localhost`     |
-| `DWN_EVENT_STREAM_PLUGIN_PATH`                    | Path to DWN Event Stream plugin to use. Default single-node implementation will be used if left empty.                  | unset                  |
-| `DWN_REGISTRATION_STORE_URL`                      | URL to use for storage of registered DIDs. Leave unset to if DWN does not require registration (ie. open for all)       | unset                  |
-| `DWN_REGISTRATION_PROOF_OF_WORK_SEED`             | Seed to generate the challenge nonce from, this allows all DWN instances in a cluster to generate the same challenge.   | unset                  |
-| `DWN_REGISTRATION_PROOF_OF_WORK_ENABLED`          | Require new users to complete a proof-of-work challenge                                                                 | `false`                |
-| `DWN_REGISTRATION_PROOF_OF_WORK_INITIAL_MAX_HASH` | Initial maximum allowed hash in 64 char HEX string. The more leading zeros (smaller number) the higher the difficulty.  | `false`                |
-| `DWN_STORAGE`                                     | URL to use for storage by default. See [Storage Options](#storage-options) for details                                  | `level://data`         |
-| `DWN_STORAGE_MESSAGES`                            | Connection URL or file path to custom plugin to use for the message store.                                              | value of `DWN_STORAGE` |
-| `DWN_STORAGE_DATA`                                | Connection URL or file path to custom plugin to use for the data store.                                                 | value of `DWN_STORAGE` |
-| `DWN_STORAGE_RESUMABLE_TASKS`                     | Connection URL or file path to custom plugin to use for the resumable task store.                                       | value of `DWN_STORAGE` |
-| `DWN_STORAGE_EVENTS`                              | Connection URL or file path to custom plugin to use for the event store.                                                | value of `DWN_STORAGE` |
-| `DWN_TERMS_OF_SERVICE_FILE_PATH`                  | Required terms of service agreement if set. Value is path to the terms of service file.                                 | unset                  |
-| `DWN_TTL_CACHE_URL`                               | URL of the TTL cache used by the DWN. Currently only supports SQL databases.                                            | `sqlite://`            |
+| Env Var                                           | Description                                                                                                                    | Default                |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------------------- |
+| `DS_PORT`                                         | Port that the server listens on                                                                                                | `3000`                 |
+| `DS_MAX_RECORD_DATA_SIZE`                         | Maximum size for `RecordsWrite` data. use `b`, `kb`, `mb`, `gb` for value                                                      | `1gb`                  |
+| `DS_WEBSOCKET_SERVER`                             | Whether to enable listening over `ws:`. values: `on`,`off`                                                                     | `on`                   |
+| `DWN_BASE_URL`                                    | Base external URL of this DWN. Used to construct URL paths such as the `Request URI` for the Web5 Connect flow.                | `http://localhost`     |
+| `DWN_EVENT_STREAM_PLUGIN_PATH`                    | Path to DWN Event Stream plugin to use. Default single-node implementation will be used if left empty.                         | unset                  |
+| `DWN_REGISTRATION_STORE_URL`                      | URL to use for storage of registered DIDs. Leave unset to if DWN does not require registration (ie. open for all)              | unset                  |
+| `DWN_REGISTRATION_PROOF_OF_WORK_SEED`             | Optional seed to generate the challenge nonce from, this allows all DWN instances in a cluster to generate the same challenge. | unset                  |
+| `DWN_REGISTRATION_PROOF_OF_WORK_ENABLED`          | Require new users to complete a proof-of-work challenge                                                                        | `false`                |
+| `DWN_REGISTRATION_PROOF_OF_WORK_INITIAL_MAX_HASH` | Initial maximum allowed hash in 64 char HEX string. The more leading zeros (smaller number) the higher the difficulty.         | `000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF` |
+| `DWN_STORAGE`                                     | URL to use for storage by default. See [Storage Options](#storage-options) for details                                         | `level://data`         |
+| `DWN_STORAGE_MESSAGES`                            | Connection URL or file path to custom plugin to use for the message store.                                                     | value of `DWN_STORAGE` |
+| `DWN_STORAGE_DATA`                                | Connection URL or file path to custom plugin to use for the data store.                                                        | value of `DWN_STORAGE` |
+| `DWN_STORAGE_RESUMABLE_TASKS`                     | Connection URL or file path to custom plugin to use for the resumable task store.                                              | value of `DWN_STORAGE` |
+| `DWN_STORAGE_EVENTS`                              | Connection URL or file path to custom plugin to use for the event store.                                                       | value of `DWN_STORAGE` |
+| `DWN_TERMS_OF_SERVICE_FILE_PATH`                  | Required terms of service agreement if set. Value is path to the terms of service file.                                        | unset                  |
+| `DWN_TTL_CACHE_URL`                               | URL of the TTL cache used by the DWN. Currently only supports SQL databases.                                                   | `sqlite://`            |
 
 ### Storage Options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@web5/dwn-server",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@web5/dwn-server",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@tbd54566975/dwn-sdk-js": "0.4.4",
         "@tbd54566975/dwn-sql-store": "0.6.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@web5/dwn-server",
   "type": "module",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
1. Updated base image used, `18-buster` failed Google store vulnerability check.
1. For more easily identifying the docker images.
1. For understanding the tag logic, because current naming is quite misleading.