### PR TITLE
config base url includes the port

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,7 @@ export const config = {
    * The base external URL of this DWN.
    * This is used to construct URL paths such as the `Request URI` in the Web5 Connect flow.
    */
-  baseUrl: process.env.DWN_BASE_URL || 'http://localhost',
+  baseUrl: process.env.DWN_BASE_URL || 'http://localhost:3000',
 
   /**
    * Port that server listens on.

--- a/src/http-api.ts
+++ b/src/http-api.ts
@@ -63,7 +63,7 @@ export class HttpApi {
 
     // create the Web5 Connect Server
     httpApi.web5ConnectServer = await Web5ConnectServer.create({
-      baseUrl: `${config.baseUrl}:${config.port}`,
+      baseUrl: config.baseUrl,
       sqlTtlCacheUrl: config.ttlCacheUrl,
     });
 

--- a/tests/http-api.spec.ts
+++ b/tests/http-api.spec.ts
@@ -199,8 +199,7 @@ describe('http api', function () {
 
   describe('P0 Scenarios', function () {
     it('should be able to read and write a protocol record', async function () {
-      const dwnUrl = `${config.baseUrl}:${config.port}`;
-      await CommonScenarioValidator.sanityTestDwnReadWrite(dwnUrl, alice)
+      await CommonScenarioValidator.sanityTestDwnReadWrite(config.baseUrl, alice)
     });
   });
 
@@ -924,7 +923,7 @@ describe('http api', function () {
       expect(resp.status).to.equal(200);
 
       const info = await resp.json();
-      expect(info['url']).to.equal('http://localhost');
+      expect(info['url']).to.equal('http://localhost:3000');
       expect(info['server']).to.equal('@web5/dwn-server');
       expect(info['registrationRequirements']).to.include('terms-of-service');
       expect(info['registrationRequirements']).to.include(

--- a/tests/scenarios/dynamic-plugin-loading.spec.ts
+++ b/tests/scenarios/dynamic-plugin-loading.spec.ts
@@ -82,7 +82,6 @@ describe('Dynamic DWN plugin loading', function () {
     expect(customEventStreamConstructorSpy.calledOnce).to.be.true;
 
     // 3. Validate that the DWN instance is using the custom data store plugin.
-    const dwnUrl = `${dwnServerConfigCopy.baseUrl}:${dwnServerConfigCopy.port}`;
-    await CommonScenarioValidator.sanityTestDwnReadWrite(dwnUrl);
+    await CommonScenarioValidator.sanityTestDwnReadWrite(dwnServerConfigCopy.baseUrl);
   });
 });


### PR DESCRIPTION
Currently the WalletConnect flow returns a fully qualified URL back to the caller, however it is returning it as a concatenation of `baseUril` and `port`. In most production systems the URL does not also include a port and so just a baseURL should be sufficient.

The environment variable is now: `DWN_BASE_URL: 'http://localhost:3000'`